### PR TITLE
feat: 커뮤니티 상세 페이지 UI 스켈레톤 구현 (#3)

### DIFF
--- a/src/components/community/CommentSection/CommentSection.tsx
+++ b/src/components/community/CommentSection/CommentSection.tsx
@@ -1,0 +1,24 @@
+export interface CommentSectionProps {
+  postId: number
+  commentCount: number
+}
+
+/**
+ * TODO(댓글): 별도 이슈에서 구현
+ * - 댓글 목록 (posts/comments GET)
+ * - 댓글 작성 폼 (회원만, posts/comments POST)
+ * - 댓글 수정/삭제 (posts/comments PUT/DELETE)
+ */
+export function CommentSection({ commentCount }: CommentSectionProps) {
+  return (
+    <section className="mt-10" aria-label="댓글">
+      <h2 className="text-text-heading mb-4 text-base font-semibold">
+        댓글{' '}
+        <span className="text-primary">{commentCount.toLocaleString()}</span>
+      </h2>
+      <div className="border-border-base bg-bg-muted text-text-muted rounded-lg border border-dashed px-6 py-14 text-center text-sm">
+        댓글 영역 (구현 예정)
+      </div>
+    </section>
+  )
+}

--- a/src/components/community/CommentSection/index.ts
+++ b/src/components/community/CommentSection/index.ts
@@ -1,0 +1,2 @@
+export { CommentSection } from './CommentSection'
+export type { CommentSectionProps } from './CommentSection'

--- a/src/components/community/PostActions/PostActions.tsx
+++ b/src/components/community/PostActions/PostActions.tsx
@@ -1,0 +1,44 @@
+export interface PostActionsProps {
+  likeCount: number
+  isLiked: boolean
+  /** false이면 좋아요 버튼 비활성화 (비회원) */
+  isLoggedIn: boolean
+  // TODO(좋아요): posts/like — POST /api/v1/posts/{post_id}/like 연동
+  onLike: () => void
+}
+
+export function PostActions({
+  likeCount,
+  isLiked,
+  isLoggedIn,
+  onLike,
+}: PostActionsProps) {
+  return (
+    <div className="border-border-base flex items-center justify-center border-y py-10">
+      <button
+        type="button"
+        onClick={onLike}
+        disabled={!isLoggedIn}
+        aria-label={isLiked ? '좋아요 취소' : '좋아요'}
+        aria-pressed={isLiked}
+        className={[
+          'flex flex-col items-center gap-2 rounded-2xl border px-10 py-4 transition-colors duration-150 outline-none',
+          'focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2',
+          isLiked
+            ? 'border-primary bg-primary-100 text-primary'
+            : 'border-border-base text-text-muted hover:border-primary hover:text-primary bg-white',
+          !isLoggedIn ? 'cursor-not-allowed opacity-50' : '',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        <span className="text-3xl leading-none" aria-hidden="true">
+          {isLiked ? '♥' : '♡'}
+        </span>
+        <span className="text-sm font-medium">
+          {likeCount.toLocaleString()}
+        </span>
+      </button>
+    </div>
+  )
+}

--- a/src/components/community/PostActions/index.ts
+++ b/src/components/community/PostActions/index.ts
@@ -1,0 +1,2 @@
+export { PostActions } from './PostActions'
+export type { PostActionsProps } from './PostActions'

--- a/src/components/community/PostAuthorActions/PostAuthorActions.tsx
+++ b/src/components/community/PostAuthorActions/PostAuthorActions.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@/components/common/Button'
+
+export interface PostAuthorActionsProps {
+  onEdit: () => void
+  onDelete: () => void
+}
+
+export function PostAuthorActions({
+  onEdit,
+  onDelete,
+}: PostAuthorActionsProps) {
+  return (
+    <div className="flex items-center justify-end gap-2 pt-3">
+      <Button variant="secondary" size="sm" onClick={onEdit}>
+        수정
+      </Button>
+      <Button variant="danger" size="sm" onClick={onDelete}>
+        삭제
+      </Button>
+    </div>
+  )
+}

--- a/src/components/community/PostAuthorActions/index.ts
+++ b/src/components/community/PostAuthorActions/index.ts
@@ -1,0 +1,2 @@
+export { PostAuthorActions } from './PostAuthorActions'
+export type { PostAuthorActionsProps } from './PostAuthorActions'

--- a/src/components/community/PostBody/PostBody.tsx
+++ b/src/components/community/PostBody/PostBody.tsx
@@ -1,0 +1,39 @@
+export interface PostBodyProps {
+  /**
+   * HTML 문자열 (리치텍스트 에디터 출력)
+   * 이미지, 제목, 목록, 인용구 등 포함 가능
+   */
+  content: string
+}
+
+export function PostBody({ content }: PostBodyProps) {
+  return (
+    <div
+      className={[
+        'text-text-body min-h-40 py-8 text-base leading-relaxed',
+        /* 단락 */
+        '[&_p]:mb-4',
+        /* 제목 */
+        '[&_h1]:text-text-heading [&_h1]:mb-4 [&_h1]:text-2xl [&_h1]:font-bold',
+        '[&_h2]:text-text-heading [&_h2]:mb-3 [&_h2]:text-xl [&_h2]:font-bold',
+        '[&_h3]:text-text-heading [&_h3]:mb-2 [&_h3]:text-lg [&_h3]:font-semibold',
+        /* 목록 */
+        '[&_ul]:mb-4 [&_ul]:list-disc [&_ul]:pl-6',
+        '[&_ol]:mb-4 [&_ol]:list-decimal [&_ol]:pl-6',
+        '[&_li]:mb-1',
+        /* 인용구 */
+        '[&_blockquote]:border-primary [&_blockquote]:text-text-muted [&_blockquote]:my-4 [&_blockquote]:border-l-4 [&_blockquote]:pl-4',
+        /* 이미지 */
+        '[&_img]:my-4 [&_img]:max-w-full [&_img]:rounded-lg',
+        /* 링크 */
+        '[&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2',
+        /* 코드 */
+        '[&_pre]:bg-bg-muted [&_pre]:my-4 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:p-4',
+        '[&_code]:bg-bg-muted [&_code]:rounded [&_code]:px-1 [&_code]:text-sm',
+        /* 구분선 */
+        '[&_hr]:border-border-base [&_hr]:my-6',
+      ].join(' ')}
+      dangerouslySetInnerHTML={{ __html: content }}
+    />
+  )
+}

--- a/src/components/community/PostBody/index.ts
+++ b/src/components/community/PostBody/index.ts
@@ -1,0 +1,2 @@
+export { PostBody } from './PostBody'
+export type { PostBodyProps } from './PostBody'

--- a/src/components/community/PostHeader/PostHeader.tsx
+++ b/src/components/community/PostHeader/PostHeader.tsx
@@ -1,0 +1,43 @@
+import { Avatar } from '@/components/common/Avatar'
+import { Badge } from '@/components/common/Badge'
+
+export interface PostHeaderProps {
+  category: string
+  title: string
+  author: {
+    nickname: string
+    profileImage: string | null
+  }
+  createdAt: string
+  viewCount: number
+}
+
+export function PostHeader({
+  category,
+  title,
+  author,
+  createdAt,
+  viewCount,
+}: PostHeaderProps) {
+  return (
+    <div className="border-border-base flex flex-col gap-3 border-b pb-6">
+      <Badge variant="primary" size="sm">
+        {category}
+      </Badge>
+
+      <h1 className="text-text-heading text-2xl leading-snug font-bold">
+        {title}
+      </h1>
+
+      <div className="text-text-muted flex items-center justify-between text-sm">
+        <div className="flex items-center gap-2">
+          <Avatar src={author.profileImage} alt={author.nickname} size="sm" />
+          <span className="text-text-body font-medium">{author.nickname}</span>
+          <span aria-hidden="true">·</span>
+          <span>{createdAt}</span>
+        </div>
+        <span>조회 {viewCount.toLocaleString()}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/community/PostHeader/index.ts
+++ b/src/components/community/PostHeader/index.ts
@@ -1,0 +1,2 @@
+export { PostHeader } from './PostHeader'
+export type { PostHeaderProps } from './PostHeader'

--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -1,8 +1,133 @@
 /**
- * @figma 커뮤니티 상세 페이지 (비회원)  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472&m=dev
- * @figma 커뮤니티 상세 페이지 (회원)  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10585&m=dev
- * @figma 커뮤니티 상세 페이지 (회원-작성자)  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10696&m=dev
+ * @figma 커뮤니티 상세 페이지 (비회원)     https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10472&m=dev
+ * @figma 커뮤니티 상세 페이지 (회원)        https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10585&m=dev
+ * @figma 커뮤니티 상세 페이지 (회원-작성자) https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10696&m=dev
  */
+import { useState } from 'react'
+import { useNavigate, useParams } from 'react-router'
+import { ConfirmModal } from '@/components/common/Modal/ConfirmModal'
+import { PostHeader } from '@/components/community/PostHeader'
+import { PostAuthorActions } from '@/components/community/PostAuthorActions'
+import { PostBody } from '@/components/community/PostBody'
+import { PostActions } from '@/components/community/PostActions'
+import { CommentSection } from '@/components/community/CommentSection'
+
+// TODO(타입): src/features/posts/detail/types.ts 로 이동
+interface PostAuthor {
+  id: number
+  nickname: string
+  profileImage: string | null
+}
+
+interface PostDetail {
+  id: number
+  title: string
+  /** HTML 문자열 (리치텍스트 에디터 출력, 이미지 포함 가능) */
+  content: string
+  category: string
+  createdAt: string
+  viewCount: number
+  likeCount: number
+  commentCount: number
+  isLiked: boolean
+  /** TODO(권한): API 응답 필드 vs authStore.userId 비교 — 방식 확정 후 교체 */
+  isAuthor: boolean
+  author: PostAuthor
+}
+
+// TODO(API): posts/detail — GET /api/v1/posts/{post_id} 연동 후 교체
+const DUMMY_POST: PostDetail = {
+  id: 0,
+  title: '(임시) 게시글 제목',
+  content: '<p>(임시) 본문 내용이 여기에 표시됩니다.</p>',
+  category: '자유',
+  createdAt: '2026-04-24',
+  viewCount: 0,
+  likeCount: 0,
+  commentCount: 0,
+  isLiked: false,
+  isAuthor: false,
+  author: { id: 0, nickname: '작성자', profileImage: null },
+}
+
 export function CommunityDetailPage() {
-  return <div>커뮤니티 상세</div>
+  const { postId } = useParams<{ postId: string }>()
+  const navigate = useNavigate()
+
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+
+  // TODO(API): posts/detail — GET /api/v1/posts/{post_id} 연동
+  const post: PostDetail = DUMMY_POST
+
+  // TODO(좋아요): authStore 로그인 상태 연동
+  const isLoggedIn = false
+
+  // TODO(로딩/에러): 로딩 중 Spinner, 에러 시 에러 메시지 처리 추가
+
+  const handleEdit = () => {
+    navigate(`/community/${postId}/edit`)
+  }
+
+  const handleDeleteConfirm = () => {
+    // TODO(API): posts/delete — DELETE /api/v1/posts/{post_id} 연동
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-10">
+      {/* 뒤로가기 */}
+      <button
+        type="button"
+        onClick={() => navigate('/community')}
+        className="text-text-muted hover:text-text-body mb-8 flex items-center gap-1.5 text-sm transition-colors"
+      >
+        <span aria-hidden="true">←</span>
+        커뮤니티 목록
+      </button>
+
+      <article>
+        {/* 헤더: 카테고리 · 제목 · 작성자 · 메타 */}
+        <PostHeader
+          category={post.category}
+          title={post.title}
+          author={post.author}
+          createdAt={post.createdAt}
+          viewCount={post.viewCount}
+        />
+
+        {/* 수정/삭제 버튼 — 작성자 전용 */}
+        {post.isAuthor && (
+          <PostAuthorActions
+            onEdit={handleEdit}
+            onDelete={() => setIsDeleteModalOpen(true)}
+          />
+        )}
+
+        {/* 본문 (HTML · 이미지 포함) */}
+        <PostBody content={post.content} />
+
+        {/* 좋아요 */}
+        <PostActions
+          likeCount={post.likeCount}
+          isLiked={post.isLiked}
+          isLoggedIn={isLoggedIn}
+          onLike={() => {
+            // TODO(좋아요): posts/like — POST /api/v1/posts/{post_id}/like 연동
+          }}
+        />
+
+        {/* 댓글 (별도 이슈) */}
+        <CommentSection postId={post.id} commentCount={post.commentCount} />
+      </article>
+
+      {/* 게시글 삭제 확인 모달 */}
+      <ConfirmModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        message={`게시글을 삭제하시겠습니까?\n삭제된 게시글은 복구할 수 없습니다.`}
+        confirmLabel="삭제"
+        danger
+        onConfirm={handleDeleteConfirm}
+      />
+    </main>
+  )
 }


### PR DESCRIPTION
## 개요

커뮤니티 상세 페이지(`/community/:postId`) UI 스켈레톤을 구현합니다.
API 연동 전 단계로, 컴포넌트 구조와 타입 초안을 확립하는 것이 목적입니다.

closes #3

## 변경 사항

**신규 컴포넌트** (`src/components/community/`)
- `PostHeader` — 카테고리 Badge, 제목, Avatar+닉네임, 날짜, 조회수
- `PostAuthorActions` — 수정/삭제 버튼 (작성자 전용 조건부 렌더)
- `PostBody` — HTML 본문 렌더링 (이미지·코드·인용구 스타일 포함)
- `PostActions` — 좋아요 버튼 (비회원 disabled, 회원 enabled)
- `CommentSection` — placeholder (별도 이슈에서 구현 예정)

**수정 파일**
- `CommunityDetailPage` — 빈 div → 전체 레이아웃 스켈레톤
  - 뒤로가기 버튼
  - 삭제 확인 `ConfirmModal`
  - `PostDetail` 타입 초안 (features 연동 후 이동 예정)

## 미구현 항목 (TODO)

- [ ] `posts/detail` API 연동 및 로딩/에러 처리
- [ ] `posts/like` 좋아요 토글 API 연동 + authStore 로그인 상태
- [ ] `isAuthor` 권한 판별 방식 확정 (API 응답 필드 vs authStore.userId 비교)
- [ ] `posts/delete` 삭제 mutation 연동 + 성공 후 리다이렉트
- [ ] `CommentSection` 댓글 기능 (별도 이슈)

## 테스트

- [ ] `http://localhost:5173/community/1` 렌더링 확인
- [ ] `DUMMY_POST.isAuthor: true` 변경 시 수정/삭제 버튼 노출 확인
- [ ] `isLoggedIn: true` 변경 시 좋아요 버튼 활성화 확인
- [ ] 삭제 버튼 클릭 시 ConfirmModal 노출 확인