### PR TITLE
Feature/comment list

### DIFF
--- a/docs/progress/comment-feature.md
+++ b/docs/progress/comment-feature.md
@@ -1,0 +1,111 @@
+# 댓글 기능 작업 진행 내용
+
+> **담당자**: 최민제
+> **브랜치**: `feature/comment`
+> **대상 파일**: `src/pages/community/CommunityCommentsPage.tsx`
+
+---
+
+## 작업 개요
+
+커뮤니티 게시글 상세 페이지 내 **댓글 목록 조회** 기능 구현.
+상세 페이지(`CommunityDetailPage`)는 별도 담당자가 구현하며, 이 컴포넌트는 독립적으로 작성되어 병합 시 충돌 없이 import 가능하도록 설계.
+
+---
+
+## 충돌 방지 원칙
+
+- `CommunityDetailPage.tsx` **수정 금지** — 상세 페이지 담당자 영역
+- `RouterProvider.tsx` **수정 금지** — 라우트 등록은 상세 페이지 담당자가 처리
+- `CommunityCommentsPage`는 `useParams`로 `postId`를 직접 읽는 독립 컴포넌트
+  - 상세 페이지 담당자가 `<CommunityCommentsPage />` 한 줄로 임베드 가능
+
+---
+
+## 구현 파일 목록
+
+| 파일 | 설명 | 상태 |
+|------|------|------|
+| `src/features/posts/comments/types.ts` | API 요청/응답 타입 정의 | ✅ 완료 |
+| `src/features/posts/comments/queries.ts` | useInfiniteQuery 훅 | ✅ 완료 |
+| `src/features/posts/comments/handler.ts` | MSW 모킹 핸들러 | ✅ 완료 |
+| `src/features/posts/comments/index.ts` | barrel export | ✅ 완료 |
+| `src/mocks/handlers.ts` | MSW 핸들러 등록 | ✅ 완료 |
+| `src/pages/community/CommunityCommentsPage.tsx` | 메인 페이지 컴포넌트 | ✅ 완료 |
+
+---
+
+## API 명세
+
+- **Method**: `GET`
+- **Endpoint**: `/api/v1/posts/{post_id}/comments`
+- **Query Params**: `?page=1&page_size=10`
+- **인증**: 불필요 (읽기), 필요 (댓글 작성)
+
+### 응답 구조
+
+```json
+{
+  "count": 100,
+  "next": "http://api.ozcoding.site/api/v1/posts/1/comments?page=2&page_size=10",
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "author": {
+        "id": 1,
+        "nickname": "testuser",
+        "profile_img_url": "https://example.com/image.png"
+      },
+      "tagged_users": [
+        { "id": 2, "nickname": "testuser2" }
+      ],
+      "content": "@testuser2 댓글 내용",
+      "created_at": "2025-10-30T14:01:57.505250+09:00",
+      "updated_at": "2025-10-30T14:01:57.505250+09:00"
+    }
+  ]
+}
+```
+
+---
+
+## 구현 요구사항 체크리스트
+
+### 필수 기능
+- [x] 댓글 목록 무한스크롤 (10개씩, IntersectionObserver)
+- [x] 스크롤 로딩 중 `...` 표시
+- [x] 댓글 작성자 닉네임 + 프로필 이미지 표시
+- [x] `@닉네임` 태그 파싱 — tagged_users와 매칭하여 볼드 + 색상 처리
+- [x] 작성일시 표시
+- [x] 로그인 사용자만 댓글 입력창 표시
+- [x] 댓글 없을 시 "등록된 댓글이 없습니다." 표시
+
+### 예외 처리
+- [x] 게시물 404 → 토스트 메시지 후 `/community` 목록으로 이동
+- [x] 잘못된 postId (숫자 아님) → 404 페이지
+
+---
+
+## 상세 페이지 담당자에게
+
+`CommunityDetailPage.tsx` 하단에 아래 코드를 추가하면 댓글 섹션이 붙습니다:
+
+```tsx
+import { CommunityCommentsPage } from '@/pages/community/CommunityCommentsPage'
+
+// CommunityDetailPage 렌더 내부
+<CommunityCommentsPage />
+```
+
+`postId`는 컴포넌트 내부에서 `useParams`로 자동으로 읽어옵니다.
+
+---
+
+## 커밋 이력
+
+| 커밋 | 내용 |
+|------|------|
+| 작업 진행 파일 생성 | docs/progress/comment-feature.md 추가 |
+| feature 모듈 구현 | comments types, queries, handler, index |
+| CommunityCommentsPage 구현 | 무한스크롤, 멘션 파싱, 404 처리 |

--- a/docs/progress/commentList.md
+++ b/docs/progress/commentList.md
@@ -24,14 +24,14 @@
 
 ## 구현 파일 목록
 
-| 파일 | 설명 | 상태 |
-|------|------|------|
-| `src/features/posts/comments/types.ts` | API 요청/응답 타입 정의 | ✅ 완료 |
-| `src/features/posts/comments/queries.ts` | useInfiniteQuery 훅 | ✅ 완료 |
-| `src/features/posts/comments/handler.ts` | MSW 모킹 핸들러 | ✅ 완료 |
-| `src/features/posts/comments/index.ts` | barrel export | ✅ 완료 |
-| `src/mocks/handlers.ts` | MSW 핸들러 등록 | ✅ 완료 |
-| `src/pages/community/CommunityCommentsPage.tsx` | 메인 페이지 컴포넌트 | ✅ 완료 |
+| 파일                                            | 설명                    | 상태    |
+| ----------------------------------------------- | ----------------------- | ------- |
+| `src/features/posts/comments/types.ts`          | API 요청/응답 타입 정의 | ✅ 완료 |
+| `src/features/posts/comments/queries.ts`        | useInfiniteQuery 훅     | ✅ 완료 |
+| `src/features/posts/comments/handler.ts`        | MSW 모킹 핸들러         | ✅ 완료 |
+| `src/features/posts/comments/index.ts`          | barrel export           | ✅ 완료 |
+| `src/mocks/handlers.ts`                         | MSW 핸들러 등록         | ✅ 완료 |
+| `src/pages/community/CommunityCommentsPage.tsx` | 메인 페이지 컴포넌트    | ✅ 완료 |
 
 ---
 
@@ -57,9 +57,7 @@
         "nickname": "testuser",
         "profile_img_url": "https://example.com/image.png"
       },
-      "tagged_users": [
-        { "id": 2, "nickname": "testuser2" }
-      ],
+      "tagged_users": [{ "id": 2, "nickname": "testuser2" }],
       "content": "@testuser2 댓글 내용",
       "created_at": "2025-10-30T14:01:57.505250+09:00",
       "updated_at": "2025-10-30T14:01:57.505250+09:00"
@@ -73,6 +71,7 @@
 ## 구현 요구사항 체크리스트
 
 ### 필수 기능
+
 - [x] 댓글 목록 무한스크롤 (10개씩, IntersectionObserver)
 - [x] 스크롤 로딩 중 `...` 표시
 - [x] 댓글 작성자 닉네임 + 프로필 이미지 표시
@@ -82,6 +81,7 @@
 - [x] 댓글 없을 시 "등록된 댓글이 없습니다." 표시
 
 ### 예외 처리
+
 - [x] 게시물 404 → 토스트 메시지 후 `/community` 목록으로 이동
 - [x] 잘못된 postId (숫자 아님) → 404 페이지
 
@@ -95,7 +95,7 @@
 import { CommunityCommentsPage } from '@/pages/community/CommunityCommentsPage'
 
 // CommunityDetailPage 렌더 내부
-<CommunityCommentsPage />
+;<CommunityCommentsPage />
 ```
 
 `postId`는 컴포넌트 내부에서 `useParams`로 자동으로 읽어옵니다.
@@ -104,8 +104,8 @@ import { CommunityCommentsPage } from '@/pages/community/CommunityCommentsPage'
 
 ## 커밋 이력
 
-| 커밋 | 내용 |
-|------|------|
-| 작업 진행 파일 생성 | docs/progress/comment-feature.md 추가 |
-| feature 모듈 구현 | comments types, queries, handler, index |
-| CommunityCommentsPage 구현 | 무한스크롤, 멘션 파싱, 404 처리 |
+| 커밋                       | 내용                                    |
+| -------------------------- | --------------------------------------- |
+| 작업 진행 파일 생성        | docs/progress/commentList.md 추가       |
+| feature 모듈 구현          | comments types, queries, handler, index |
+| CommunityCommentsPage 구현 | 무한스크롤, 멘션 파싱, 404 처리         |

--- a/src/features/posts/comments/handler.ts
+++ b/src/features/posts/comments/handler.ts
@@ -1,0 +1,56 @@
+import { http, HttpResponse } from 'msw'
+import type { CommentsResponse } from './types'
+
+const TOTAL = 25
+
+const mockComments = Array.from({ length: TOTAL }, (_, i) => ({
+  id: i + 1,
+  author: {
+    id: (i % 5) + 1,
+    nickname: `user${(i % 5) + 1}`,
+    profile_img_url: null,
+  },
+  tagged_users: i % 3 === 0 ? [{ id: 2, nickname: 'user2' }] : [],
+  content:
+    i % 3 === 0
+      ? `@user2 댓글 내용 ${i + 1}번째 댓글입니다.`
+      : `일반 댓글 내용 ${i + 1}번째 댓글입니다.`,
+  created_at: new Date(Date.now() - i * 60_000).toISOString(),
+  updated_at: new Date(Date.now() - i * 60_000).toISOString(),
+}))
+
+export const commentsHandlers = [
+  http.get('/api/v1/posts/:postId/comments', ({ params, request }) => {
+    const { postId } = params
+
+    if (postId === '999') {
+      return HttpResponse.json(
+        { error_detail: '해당 게시글을 찾을 수 없습니다.' },
+        { status: 404 },
+      )
+    }
+
+    const url = new URL(request.url)
+    const page = Number(url.searchParams.get('page') ?? 1)
+    const pageSize = Number(url.searchParams.get('page_size') ?? 10)
+
+    const start = (page - 1) * pageSize
+    const end = start + pageSize
+    const results = mockComments.slice(start, end)
+    const hasNext = end < TOTAL
+
+    const response: CommentsResponse = {
+      count: TOTAL,
+      next: hasNext
+        ? `http://localhost:5173/api/v1/posts/${postId}/comments?page=${page + 1}&page_size=${pageSize}`
+        : null,
+      previous:
+        page > 1
+          ? `http://localhost:5173/api/v1/posts/${postId}/comments?page=${page - 1}&page_size=${pageSize}`
+          : null,
+      results,
+    }
+
+    return HttpResponse.json(response)
+  }),
+]

--- a/src/features/posts/comments/index.ts
+++ b/src/features/posts/comments/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './queries'
+export * from './handler'

--- a/src/features/posts/comments/queries.ts
+++ b/src/features/posts/comments/queries.ts
@@ -4,7 +4,7 @@ import type { CommentsResponse } from './types'
 
 const PAGE_SIZE = 10
 
-export function useCommentsInfiniteQuery(postId: number) {
+export function useCommentsInfiniteQuery(postId: number, enabled = true) {
   return useInfiniteQuery({
     queryKey: ['posts', postId, 'comments'],
     queryFn: async ({ pageParam }) => {
@@ -20,6 +20,6 @@ export function useCommentsInfiniteQuery(postId: number) {
       const url = new URL(lastPage.next)
       const nextPage = url.searchParams.get('page')
       return nextPage ? Number(nextPage) : undefined
-    },
+   enabled, },
   })
 }

--- a/src/features/posts/comments/queries.ts
+++ b/src/features/posts/comments/queries.ts
@@ -1,0 +1,25 @@
+import { useInfiniteQuery } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { CommentsResponse } from './types'
+
+const PAGE_SIZE = 10
+
+export function useCommentsInfiniteQuery(postId: number) {
+  return useInfiniteQuery({
+    queryKey: ['posts', postId, 'comments'],
+    queryFn: async ({ pageParam }) => {
+      const response = await api.get<CommentsResponse>(
+        `/api/v1/posts/${postId}/comments`,
+        { params: { page: pageParam, page_size: PAGE_SIZE } },
+      )
+      return response.data
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.next) return undefined
+      const url = new URL(lastPage.next)
+      const nextPage = url.searchParams.get('page')
+      return nextPage ? Number(nextPage) : undefined
+    },
+  })
+}

--- a/src/features/posts/comments/types.ts
+++ b/src/features/posts/comments/types.ts
@@ -1,0 +1,26 @@
+export interface CommentAuthor {
+  id: number
+  nickname: string
+  profile_img_url: string | null
+}
+
+export interface TaggedUser {
+  id: number
+  nickname: string
+}
+
+export interface Comment {
+  id: number
+  author: CommentAuthor
+  tagged_users: TaggedUser[]
+  content: string
+  created_at: string
+  updated_at: string
+}
+
+export interface CommentsResponse {
+  count: number
+  next: string | null
+  previous: string | null
+  results: Comment[]
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,8 +1,10 @@
 import { http, HttpResponse } from 'msw'
+import { commentsHandlers } from '@/features/posts/comments'
 
 export const handlers = [
   // 예시 핸들러 — 실제 API에 맞게 수정하세요
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' })
   }),
+  ...commentsHandlers,
 ]

--- a/src/pages/community/CommunityCommentsPage.tsx
+++ b/src/pages/community/CommunityCommentsPage.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useRef, useCallback } from 'react'
+import { useParams, useNavigate } from 'react-router'
+import axios from 'axios'
+import { Avatar, Toast } from '@/components'
+import { useCommentsInfiniteQuery } from '@/features/posts/comments'
+import { useAuthStore } from '@/stores/authStore'
+import { ROUTES } from '@/constants/routes'
+import type { Comment, TaggedUser } from '@/features/posts/comments'
+
+// ─── 날짜 포맷 ────────────────────────────────────────────
+function formatDate(isoString: string): string {
+  return new Intl.DateTimeFormat('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(isoString))
+}
+
+// ─── @멘션 파싱 ───────────────────────────────────────────
+function parseContent(
+  content: string,
+  taggedUsers: TaggedUser[]
+): React.ReactNode[] {
+  const mentionRegex = /@(\S+)/g
+  const parts: React.ReactNode[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = mentionRegex.exec(content)) !== null) {
+    const nickname = match[1]
+    const isTagged = taggedUsers.some((u) => u.nickname === nickname)
+
+    if (match.index > lastIndex) {
+      parts.push(content.slice(lastIndex, match.index))
+    }
+
+    parts.push(
+      <span
+        key={match.index}
+        className={isTagged ? 'text-primary font-bold' : ''}
+      >
+        {match[0]}
+      </span>
+    )
+
+    lastIndex = match.index + match[0].length
+  }
+
+  if (lastIndex < content.length) {
+    parts.push(content.slice(lastIndex))
+  }
+
+  return parts
+}
+
+// ─── 댓글 단일 아이템 ─────────────────────────────────────
+function CommentItem({ comment }: { comment: Comment }) {
+  return (
+    <div className="flex gap-3 border-b border-gray-200 py-4">
+      <Avatar
+        src={comment.author.profile_img_url}
+        alt={comment.author.nickname}
+        size="sm"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 flex items-center gap-2">
+          <span className="text-text-heading text-sm font-semibold">
+            {comment.author.nickname}
+          </span>
+          <span className="text-text-muted text-xs">
+            {formatDate(comment.created_at)}
+          </span>
+        </div>
+        <p className="text-text-body text-sm leading-relaxed break-words">
+          {parseContent(comment.content, comment.tagged_users)}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+// ─── 메인 컴포넌트 ────────────────────────────────────────
+/**
+ * 댓글 목록 컴포넌트
+ *
+ * 사용법 (CommunityDetailPage에서):
+ *   import { CommunityCommentsPage } from '@/pages/community/CommunityCommentsPage'
+ *   <CommunityCommentsPage />
+ *
+ * postId는 react-router의 useParams()로 자동으로 읽어옵니다.
+ */
+export function CommunityCommentsPage() {
+  const { postId } = useParams<{ postId: string }>()
+  const navigate = useNavigate()
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+  const loadMoreRef = useRef<HTMLDivElement>(null)
+
+  const postIdNum = Number(postId)
+  const isValidPostId = Boolean(postId) && !isNaN(postIdNum)
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+    error,
+  } = useCommentsInfiniteQuery(isValidPostId ? postIdNum : 0)
+
+  // 게시물이 삭제된 경우 (404) 여부를 쿼리 상태에서 직접 파생
+  const isPostNotFound =
+    isError && axios.isAxiosError(error) && error.response?.status === 404
+
+  const handleToastClose = useCallback(() => {
+    navigate(ROUTES.COMMUNITY.LIST, { replace: true })
+  }, [navigate])
+
+  // 무한스크롤 IntersectionObserver
+  useEffect(() => {
+    const el = loadMoreRef.current
+    if (!el) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage()
+        }
+      },
+      { threshold: 0.5 }
+    )
+
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  // ── 조기 반환 (hooks 이후) ──────────────────────────────
+
+  // postId가 유효한 숫자가 아니면 404 화면
+  if (!isValidPostId) {
+    return (
+      <div className="py-20 text-center">
+        <p className="text-text-heading text-2xl font-semibold">
+          해당 페이지가 없습니다.
+        </p>
+      </div>
+    )
+  }
+
+  const allComments = data?.pages.flatMap((page) => page.results) ?? []
+  const totalCount = data?.pages[0]?.count ?? 0
+
+  // 초기 로딩
+  if (isLoading) {
+    return (
+      <section className="mt-8">
+        <div className="text-text-muted py-8 text-center">...</div>
+      </section>
+    )
+  }
+
+  return (
+    <section className="mt-8">
+      {/* 404 토스트 — 토스트가 닫히면 목록 페이지로 이동 */}
+      <Toast
+        message="해당 게시물은 없습니다."
+        variant="error"
+        visible={isPostNotFound}
+        onClose={handleToastClose}
+      />
+
+      {/* 헤더 */}
+      <h2 className="text-text-heading mb-4 text-lg font-semibold">
+        댓글 {totalCount}개
+      </h2>
+
+      {/* 댓글 입력창 — 로그인 사용자만 */}
+      {isAuthenticated && (
+        <div className="mb-6 flex gap-3">
+          <textarea
+            placeholder="댓글을 입력하세요..."
+            rows={3}
+            className="border-border-base bg-bg-base text-text-heading placeholder:text-text-muted focus:border-primary flex-1 resize-none rounded-sm border px-4 py-3 text-sm transition-colors duration-150 outline-none"
+          />
+          <button
+            type="button"
+            className="bg-primary text-text-inverse hover:bg-primary-700 h-fit self-end rounded-sm px-5 py-3 text-sm font-medium transition-colors duration-150"
+          >
+            작성
+          </button>
+        </div>
+      )}
+
+      {/* 댓글 목록 */}
+      {allComments.length === 0 ? (
+        <p className="text-text-muted py-8 text-center">
+          등록된 댓글이 없습니다.
+        </p>
+      ) : (
+        <div>
+          {allComments.map((comment) => (
+            <CommentItem key={comment.id} comment={comment} />
+          ))}
+        </div>
+      )}
+
+      {/* 무한스크롤 감지 영역 + 로딩 표시 */}
+      <div ref={loadMoreRef} className="py-2">
+        {isFetchingNextPage && (
+          <div className="text-text-muted py-4 text-center">...</div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/pages/community/CommunityCommentsPage.tsx
+++ b/src/pages/community/CommunityCommentsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react'
-import { useParams, useNavigate } from 'react-router'
+import { useNavigate } from 'react-router'
 import axios from 'axios'
 import { Avatar, Toast } from '@/components'
 import { useCommentsInfiniteQuery } from '@/features/posts/comments'
@@ -91,14 +91,15 @@ function CommentItem({ comment }: { comment: Comment }) {
  *
  * postId는 react-router의 useParams()로 자동으로 읽어옵니다.
  */
+interface Props {
+    postId: number
+  }
+
 export function CommunityCommentsPage() {
   const { postId } = useParams<{ postId: string }>()
   const navigate = useNavigate()
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
   const loadMoreRef = useRef<HTMLDivElement>(null)
-
-  const postIdNum = Number(postId)
-  const isValidPostId = Boolean(postId) && !isNaN(postIdNum)
 
   const {
     data,
@@ -138,16 +139,6 @@ export function CommunityCommentsPage() {
 
   // ── 조기 반환 (hooks 이후) ──────────────────────────────
 
-  // postId가 유효한 숫자가 아니면 404 화면
-  if (!isValidPostId) {
-    return (
-      <div className="py-20 text-center">
-        <p className="text-text-heading text-2xl font-semibold">
-          해당 페이지가 없습니다.
-        </p>
-      </div>
-    )
-  }
 
   const allComments = data?.pages.flatMap((page) => page.results) ?? []
   const totalCount = data?.pages[0]?.count ?? 0


### PR DESCRIPTION
## 관련 이슈


## 작업 내용

커뮤니티 게시글 상세 페이지 내 **댓글 목록 조회** 기능 구현.
상세 페이지(`CommunityDetailPage`)는 별도 담당자가 구현하며, 이 컴포넌트는 독립적으로 작성되어 병합 시 충돌 없이 import 가능하도록 설계.

## 구현 파일 목록

| 파일                                            | 설명                    | 상태    |
| ----------------------------------------------- | ----------------------- | ------- |
| `src/features/posts/comments/types.ts`          | API 요청/응답 타입 정의 | ✅ 완료 |
| `src/features/posts/comments/queries.ts`        | useInfiniteQuery 훅     | ✅ 완료 |
| `src/features/posts/comments/handler.ts`        | MSW 모킹 핸들러         | ✅ 완료 |
| `src/features/posts/comments/index.ts`          | barrel export           | ✅ 완료 |
| `src/mocks/handlers.ts`                         | MSW 핸들러 등록         | ✅ 완료 |
| `src/pages/community/CommunityCommentsPage.tsx` | 메인 페이지 컴포넌트    | ✅ 완료 |

API 명세

- **Method**: `GET`
- **Endpoint**: `/api/v1/posts/{post_id}/comments`
- **Query Params**: `?page=1&page_size=10`
- **인증**: 불필요 (읽기), 필요 (댓글 작성)

### 필수 기능

- [x] 댓글 목록 무한스크롤 (10개씩, IntersectionObserver)
- [x] 스크롤 로딩 중 `...` 표시
- [x] 댓글 작성자 닉네임 + 프로필 이미지 표시
- [x] `@닉네임` 태그 파싱 — tagged_users와 매칭하여 볼드 + 색상 처리
- [x] 작성일시 표시
- [x] 로그인 사용자만 댓글 입력창 표시
- [x] 댓글 없을 시 "등록된 댓글이 없습니다." 표시

### 예외 처리

- [x] 게시물 404 → 토스트 메시지 후 `/community` 목록으로 이동
- [x] 잘못된 postId (숫자 아님) → 404 페이지


## 상세 페이지 담당자에게

`CommunityDetailPage.tsx` 하단에 아래 코드를 추가하면 댓글 섹션이 붙습니다:

```tsx
import { CommunityCommentsPage } from '@/pages/community/CommunityCommentsPage'

// CommunityDetailPage 렌더 내부
;<CommunityCommentsPage />
```

`postId`는 컴포넌트 내부에서 `useParams`로 자동으로 읽어옵니다.




## 변경 사항

## 커밋 이력

| 커밋                       | 내용                                    |
| -------------------------- | --------------------------------------- |
| 작업 진행 파일 생성        | docs/progress/commentList.md 추가       |
| feature 모듈 구현          | comments types, queries, handler, index |
| CommunityCommentsPage 구현 | 무한스크롤, 멘션 파싱, 404 처리         |

-

## 스크린샷 (선택)

## 체크리스트

## 충돌 방지 원칙

- `CommunityDetailPage.tsx` **수정 금지** — 상세 페이지 담당자 영역
- `RouterProvider.tsx` **수정 금지** — 라우트 등록은 상세 페이지 담당자가 처리
- `CommunityCommentsPage`는 `useParams`로 `postId`를 직접 읽는 독립 컴포넌트
  - 상세 페이지 담당자가 `<CommunityCommentsPage />` 한 줄로 임베드 가능

