### PR TITLE
style: 게시글 상세 페이지 Figma UI 반영 (#34)

### DIFF
--- a/docs/progress/communityDetailFigma.md
+++ b/docs/progress/communityDetailFigma.md
@@ -17,13 +17,14 @@
 
 ## 변경 파일 목록
 
-| 파일                                                               | 변경 내용                                                                    | 상태    |
-| ------------------------------------------------------------------ | ---------------------------------------------------------------------------- | ------- |
-| `src/pages/community/CommunityDetailPage.tsx`                      | `pt-16` 상단 여백, 구분선 추가, 레이아웃 조정                                | ✅ 완료 |
-| `src/components/community/PostHeader/PostHeader.tsx`               | 카테고리 `text-xl font-bold`, 제목 `text-[32px]`, Avatar `lg`, 메타 레이아웃 | ✅ 완료 |
-| `src/components/community/PostAuthorActions/PostAuthorActions.tsx` | 수정(`text-primary`) / 삭제(`text-gray-500`) 텍스트 버튼, 세로 구분선        | ✅ 완료 |
-| `src/components/community/PostBody/PostBody.tsx`                   | 본문 색상 `text-text-heading`, 상하 여백 `py-10`                             | ✅ 완료 |
-| `src/components/community/PostActions/PostActions.tsx`             | 좋아요 pill shape, 공유하기 버튼(링크 복사) 추가                             | ✅ 완료 |
+| 파일                                                               | 변경 내용                                                                                              | 상태    |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ | ------- |
+| `src/pages/community/CommunityDetailPage.tsx`                      | `pt-16` 상단 여백, 구분선 추가, 레이아웃 조정, 구분선 색상 조정                                        | ✅ 완료 |
+| `src/components/community/PostHeader/PostHeader.tsx`               | 카테고리 `text-xl font-bold`, 제목 `text-[32px]`, Avatar `lg`, 메타 레이아웃, 좋아요 수·상대 시간 추가 | ✅ 완료 |
+| `src/components/community/PostAuthorActions/PostAuthorActions.tsx` | 수정(`text-primary`) / 삭제(`text-gray-500`) 텍스트 버튼, 세로 구분선                                  | ✅ 완료 |
+| `src/components/community/PostBody/PostBody.tsx`                   | 본문 색상 `text-text-heading`, 상하 여백 `py-10`                                                       | ✅ 완료 |
+| `src/components/community/PostActions/PostActions.tsx`             | 좋아요 pill shape, 공유하기 버튼(링크 복사) 추가                                                       | ✅ 완료 |
+| `src/components/common/Avatar/Avatar.tsx`                          | 이미지 로드 실패 시 이니셜 fallback (`onError` 처리)                                                   | ✅ 완료 |
 
 ---
 
@@ -34,7 +35,10 @@
 - 카테고리 뱃지: `text-primary text-xl font-bold` — Figma 주요 색상·크기 반영
 - 제목: `text-[32px] leading-snug font-bold` — 정확한 픽셀값으로 지정
 - 프로필 영역: `Avatar size="lg"` + 닉네임 `text-base font-semibold text-gray-600`
-- 메타(조회수·날짜): `flex gap-1 text-base text-gray-400` + `·` 구분자
+- 메타 정보: `조회수 n · 좋아요 n · n시간 전` 형식으로 변경
+  - 좋아요 수(`likeCount`) prop 추가 — 좋아요 클릭 시 실시간 반영
+  - 상대 시간 표시: `방금 전 / n분 전 / n시간 전 / n일 전` (`formatRelativeTime` 헬퍼)
+  - 기존 ISO 날짜 문자열 그대로 전달, 렌더링 시 변환
 
 ### PostAuthorActions
 
@@ -59,8 +63,14 @@
 ### CommunityDetailPage
 
 - 최상단 컨테이너 `pt-16` 상단 여백 추가
-- 헤더 하단, 본문 하단에 `<hr />` 구분선 삽입
+- 헤더 하단, 본문 하단에 구분선 삽입 — `bg-gray-200` (옅은 회색)
 - 작성자 본인일 때만 `PostAuthorActions` 렌더링 (기존 `isAuthor` 로직 유지)
+- `PostHeader`에 `likeCount` 전달 (좋아요 클릭 시 메타 정보 즉시 반영)
+
+### Avatar (공통 컴포넌트)
+
+- 이미지 URL이 있어도 로드 실패 시 이니셜 fallback 표시
+- `useState(false)`로 에러 상태 관리, `onError={() => setImgError(true)}`
 
 ---
 
@@ -71,11 +81,13 @@
 - [x] 카테고리 텍스트 스타일 (`text-primary text-xl font-bold`)
 - [x] 제목 32px, 굵게
 - [x] Avatar 크기 `lg`
-- [x] 조회수·날짜 메타 정보 레이아웃
+- [x] 메타 정보: `조회수 n · 좋아요 n · n시간 전` 형식
+- [x] 상대 시간 표시 (`방금 전 / n분 전 / n시간 전 / n일 전`)
 - [x] 수정/삭제 텍스트 버튼 + 세로 구분선
 - [x] 본문 영역 색상 및 여백
 - [x] 좋아요 pill shape, 상태별 색상 토글
-- [x] 페이지 상단 여백 및 구분선
+- [x] 페이지 상단 여백 및 구분선 (`bg-gray-200`)
+- [x] 프로필 이미지 로드 실패 시 이니셜 fallback
 
 ### 공유하기 기능
 
@@ -108,3 +120,5 @@ CommunityDetailPage
 | `style: 공유하기 버튼 Figma 디자인 반영 (#34)`                                          | PostActions pill shape, 링크 아이콘 반영                                 |
 | `refactor: reorder share and like buttons in PostActions component`                     | 좋아요→공유하기 버튼 순서 조정                                           |
 | `refactor: PostAuthorActions와 PostActions에서 기본 버튼을 공통 Button 컴포넌트로 교체` | variant="ghost" 공통 컴포넌트 적용                                       |
+| `style: 게시글 상세 페이지 메타 정보 UI 개선 (#34)`                                     | 메타 정보 형식 변경, 상대 시간, Avatar 이미지 fallback                   |
+| `style: 구분선 색상 조정 (#34)`                                                         | `bg-gray-200`으로 조정                                                   |

--- a/docs/progress/communityDetailFigma.md
+++ b/docs/progress/communityDetailFigma.md
@@ -1,0 +1,110 @@
+# 게시글 상세 페이지 Figma UI 반영 작업 내용
+
+> **담당자**: 이선영
+> **브랜치**: `style/community-detail-figma-ui`
+> **관련 이슈**: `#34`
+> **PR**: `#36` (`style/community-detail-figma-ui` → `dev`)
+
+---
+
+## 작업 개요
+
+게시글 상세 페이지(`CommunityDetailPage`) 및 하위 컴포넌트에 **Figma 디자인 반영**.
+기존 API 연동 기반의 동작 코드는 유지하면서, 레이아웃·타이포그래피·색상·버튼 형태를 Figma 스펙에 맞게 교체.
+공유하기 버튼(링크 복사)도 이 PR에서 함께 구현.
+
+---
+
+## 변경 파일 목록
+
+| 파일                                                               | 변경 내용                                                                    | 상태    |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------- | ------- |
+| `src/pages/community/CommunityDetailPage.tsx`                      | `pt-16` 상단 여백, 구분선 추가, 레이아웃 조정                                | ✅ 완료 |
+| `src/components/community/PostHeader/PostHeader.tsx`               | 카테고리 `text-xl font-bold`, 제목 `text-[32px]`, Avatar `lg`, 메타 레이아웃 | ✅ 완료 |
+| `src/components/community/PostAuthorActions/PostAuthorActions.tsx` | 수정(`text-primary`) / 삭제(`text-gray-500`) 텍스트 버튼, 세로 구분선        | ✅ 완료 |
+| `src/components/community/PostBody/PostBody.tsx`                   | 본문 색상 `text-text-heading`, 상하 여백 `py-10`                             | ✅ 완료 |
+| `src/components/community/PostActions/PostActions.tsx`             | 좋아요 pill shape, 공유하기 버튼(링크 복사) 추가                             | ✅ 완료 |
+
+---
+
+## 컴포넌트별 주요 변경 사항
+
+### PostHeader
+
+- 카테고리 뱃지: `text-primary text-xl font-bold` — Figma 주요 색상·크기 반영
+- 제목: `text-[32px] leading-snug font-bold` — 정확한 픽셀값으로 지정
+- 프로필 영역: `Avatar size="lg"` + 닉네임 `text-base font-semibold text-gray-600`
+- 메타(조회수·날짜): `flex gap-1 text-base text-gray-400` + `·` 구분자
+
+### PostAuthorActions
+
+- 수정 버튼: `text-primary` 색상의 텍스트 버튼
+- 삭제 버튼: `text-gray-500` 색상의 텍스트 버튼
+- 두 버튼 사이: `|` 세로 구분선 (`text-gray-300`)
+- 공통 `Button` 컴포넌트(`variant="ghost"`) 사용
+
+### PostBody
+
+- 본문 래퍼 색상: `text-text-heading` (디자인 토큰)
+- 본문 상하 여백: `py-10`
+
+### PostActions
+
+- 좋아요 버튼: pill shape(`rounded-full`) + 좋아요 상태에 따라 `border-primary bg-primary-50 text-primary` ↔ `border-gray-300 text-gray-500`
+- 공유하기 버튼: pill shape + `navigator.clipboard.writeText`로 현재 URL 복사
+  - 복사 성공 시 2초간 "복사됨!" 텍스트 피드백
+  - 링크 아이콘(SVG) + "공유하기" 텍스트
+- 두 버튼 모두 `Button variant="ghost"` 공통 컴포넌트로 교체 (`refactor` 커밋에서 진행)
+
+### CommunityDetailPage
+
+- 최상단 컨테이너 `pt-16` 상단 여백 추가
+- 헤더 하단, 본문 하단에 `<hr />` 구분선 삽입
+- 작성자 본인일 때만 `PostAuthorActions` 렌더링 (기존 `isAuthor` 로직 유지)
+
+---
+
+## 구현 요구사항 체크리스트
+
+### Figma UI 반영
+
+- [x] 카테고리 텍스트 스타일 (`text-primary text-xl font-bold`)
+- [x] 제목 32px, 굵게
+- [x] Avatar 크기 `lg`
+- [x] 조회수·날짜 메타 정보 레이아웃
+- [x] 수정/삭제 텍스트 버튼 + 세로 구분선
+- [x] 본문 영역 색상 및 여백
+- [x] 좋아요 pill shape, 상태별 색상 토글
+- [x] 페이지 상단 여백 및 구분선
+
+### 공유하기 기능
+
+- [x] 현재 페이지 URL을 클립보드에 복사
+- [x] 복사 성공 시 2초간 "복사됨!" 피드백
+- [x] Figma 디자인 반영 (pill shape, 링크 아이콘)
+- [x] 공통 `Button` 컴포넌트 활용
+
+---
+
+## 상세 페이지 연결 구조
+
+```
+CommunityDetailPage
+├── PostHeader          — 카테고리, 제목, 프로필, 메타
+├── PostAuthorActions   — 수정/삭제 (isAuthor일 때만)
+├── PostBody            — 본문 HTML 렌더
+├── PostActions         — 좋아요, 공유하기
+└── CommunityCommentsPage — 댓글 (별도 PR에서 구현)
+```
+
+---
+
+## 커밋 이력
+
+| 커밋 메시지                                                                             | 내용                                                                     |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `style: 게시글 상세 페이지 Figma UI 반영 (#34)`                                         | PostHeader, PostAuthorActions, PostBody, CommunityDetailPage 스타일 반영 |
+| `feat: 게시글 공유하기 버튼 구현 (#34)`                                                 | navigator.clipboard 복사, "복사됨!" 피드백                               |
+| `style: 공유하기 버튼 Figma 디자인 반영 (#34)`                                          | PostActions pill shape, 링크 아이콘 반영                                 |
+| `refactor: reorder share and like buttons in PostActions component`                     | 좋아요→공유하기 버튼 순서 조정                                           |
+| `refactor: PostAuthorActions와 PostActions에서 기본 버튼을 공통 Button 컴포넌트로 교체` | variant="ghost" 공통 컴포넌트 적용                                       |

--- a/docs/progress/communityDetailFigma.md
+++ b/docs/progress/communityDetailFigma.md
@@ -1,6 +1,6 @@
 # 게시글 상세 페이지 Figma UI 반영 작업 내용
 
-> **담당자**: 이선영
+> **담당자**: 정선영
 > **브랜치**: `style/community-detail-figma-ui`
 > **관련 이슈**: `#34`
 > **PR**: `#36` (`style/community-detail-figma-ui` → `dev`)

--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 export type AvatarSize = 'sm' | 'md' | 'lg' | 'xl'
 
 export interface AvatarProps {
@@ -31,6 +33,8 @@ export function Avatar({
   className = '',
 }: AvatarProps) {
   const letters = deriveInitials(alt, initials)
+  const [imgError, setImgError] = useState(false)
+  const showImage = src && !imgError
 
   return (
     <span
@@ -39,18 +43,19 @@ export function Avatar({
       className={[
         'inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full font-semibold select-none',
         sizeClasses[size],
-        !src ? 'bg-primary-100 text-primary-700' : '',
+        !showImage ? 'bg-primary-100 text-primary-700' : '',
         className,
       ]
         .filter(Boolean)
         .join(' ')}
     >
-      {src ? (
+      {showImage ? (
         <img
           src={src}
           alt=""
           aria-hidden="true"
           className="h-full w-full object-cover"
+          onError={() => setImgError(true)}
         />
       ) : (
         <span aria-hidden="true">{letters}</span>

--- a/src/components/community/PostActions/PostActions.tsx
+++ b/src/components/community/PostActions/PostActions.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Button } from '@/components/common/Button'
 
 export interface PostActionsProps {
   likeCount: number
@@ -28,18 +29,19 @@ export function PostActions({
   return (
     <div className="flex items-center justify-end gap-3 py-6">
       {/* 좋아요 버튼 */}
-      <button
+      <Button
+        variant="ghost"
         type="button"
         onClick={onLike}
         disabled={!isLoggedIn}
         aria-label={isLiked ? '좋아요 취소' : '좋아요'}
         aria-pressed={isLiked}
         className={[
-          'flex items-center gap-1 rounded-full border px-4 py-2.5 text-xs transition-colors duration-150 outline-none',
+          'flex h-auto! items-center gap-1 rounded-full! border bg-transparent! px-4! py-2.5! text-xs! transition-colors duration-150 outline-none',
           'focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2',
           isLiked
-            ? 'border-primary bg-primary-50 text-primary'
-            : 'hover:border-primary hover:text-primary border-gray-300 text-gray-500',
+            ? 'border-primary bg-primary-50! text-primary'
+            : 'hover:border-primary hover:text-primary! border-gray-300 text-gray-500! hover:bg-transparent!',
           !isLoggedIn ? 'cursor-not-allowed opacity-50' : '',
         ]
           .filter(Boolean)
@@ -59,14 +61,15 @@ export function PostActions({
           <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
         </svg>
         <span className="font-normal">{likeCount.toLocaleString()}</span>
-      </button>
+      </Button>
 
       {/* 공유 버튼 */}
-      <button
+      <Button
+        variant="ghost"
         type="button"
         onClick={handleShare}
         aria-label="게시글 링크 복사"
-        className="border-border-base text-text-body hover:text-text-heading flex items-center gap-1.5 rounded-full border px-4 py-2.5 text-sm transition-colors duration-150 outline-none hover:border-gray-400 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
+        className="border-border-base text-text-body! hover:text-text-heading! flex h-auto! items-center gap-1.5 rounded-full! border bg-transparent! px-4! py-2.5! text-sm! transition-colors duration-150 outline-none hover:border-gray-400 hover:bg-transparent! focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
       >
         <svg
           width="16"
@@ -83,7 +86,7 @@ export function PostActions({
           <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
         </svg>
         <span className="font-medium">{copied ? '복사됨!' : '공유하기'}</span>
-      </button>
+      </Button>
     </div>
   )
 }

--- a/src/components/community/PostActions/PostActions.tsx
+++ b/src/components/community/PostActions/PostActions.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 export interface PostActionsProps {
   likeCount: number
   isLiked: boolean
@@ -5,6 +7,7 @@ export interface PostActionsProps {
   isLoggedIn: boolean
   // TODO(좋아요): posts/like — POST /api/v1/posts/{post_id}/like 연동
   onLike: () => void
+  onShare: () => Promise<void>
 }
 
 export function PostActions({
@@ -12,9 +15,44 @@ export function PostActions({
   isLiked,
   isLoggedIn,
   onLike,
+  onShare,
 }: PostActionsProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleShare = async () => {
+    await onShare()
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
   return (
     <div className="flex items-center justify-end gap-3 py-6">
+      {/* 공유 버튼 */}
+      <button
+        type="button"
+        onClick={handleShare}
+        aria-label="게시글 링크 복사"
+        className="flex items-center gap-1 rounded-full border border-gray-300 px-4 py-2.5 text-xs text-gray-500 transition-colors duration-150 outline-none hover:border-gray-400 hover:text-gray-700 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
+      >
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+          <polyline points="16 6 12 2 8 6" />
+          <line x1="12" y1="2" x2="12" y2="15" />
+        </svg>
+        <span className="font-normal">{copied ? '복사됨!' : '공유'}</span>
+      </button>
+
+      {/* 좋아요 버튼 */}
       <button
         type="button"
         onClick={onLike}

--- a/src/components/community/PostActions/PostActions.tsx
+++ b/src/components/community/PostActions/PostActions.tsx
@@ -32,11 +32,11 @@ export function PostActions({
         type="button"
         onClick={handleShare}
         aria-label="게시글 링크 복사"
-        className="flex items-center gap-1 rounded-full border border-gray-300 px-4 py-2.5 text-xs text-gray-500 transition-colors duration-150 outline-none hover:border-gray-400 hover:text-gray-700 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
+        className="border-border-base text-text-body hover:text-text-heading flex items-center gap-1.5 rounded-full border px-4 py-2.5 text-sm transition-colors duration-150 outline-none hover:border-gray-400 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
       >
         <svg
-          width="18"
-          height="18"
+          width="16"
+          height="16"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
@@ -45,11 +45,10 @@ export function PostActions({
           strokeLinejoin="round"
           aria-hidden="true"
         >
-          <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
-          <polyline points="16 6 12 2 8 6" />
-          <line x1="12" y1="2" x2="12" y2="15" />
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
         </svg>
-        <span className="font-normal">{copied ? '복사됨!' : '공유'}</span>
+        <span className="font-medium">{copied ? '복사됨!' : '공유하기'}</span>
       </button>
 
       {/* 좋아요 버튼 */}

--- a/src/components/community/PostActions/PostActions.tsx
+++ b/src/components/community/PostActions/PostActions.tsx
@@ -27,30 +27,6 @@ export function PostActions({
 
   return (
     <div className="flex items-center justify-end gap-3 py-6">
-      {/* 공유 버튼 */}
-      <button
-        type="button"
-        onClick={handleShare}
-        aria-label="게시글 링크 복사"
-        className="border-border-base text-text-body hover:text-text-heading flex items-center gap-1.5 rounded-full border px-4 py-2.5 text-sm transition-colors duration-150 outline-none hover:border-gray-400 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
-      >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-        </svg>
-        <span className="font-medium">{copied ? '복사됨!' : '공유하기'}</span>
-      </button>
-
       {/* 좋아요 버튼 */}
       <button
         type="button"
@@ -83,6 +59,30 @@ export function PostActions({
           <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
         </svg>
         <span className="font-normal">{likeCount.toLocaleString()}</span>
+      </button>
+
+      {/* 공유 버튼 */}
+      <button
+        type="button"
+        onClick={handleShare}
+        aria-label="게시글 링크 복사"
+        className="border-border-base text-text-body hover:text-text-heading flex items-center gap-1.5 rounded-full border px-4 py-2.5 text-sm transition-colors duration-150 outline-none hover:border-gray-400 focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </svg>
+        <span className="font-medium">{copied ? '복사됨!' : '공유하기'}</span>
       </button>
     </div>
   )

--- a/src/components/community/PostActions/PostActions.tsx
+++ b/src/components/community/PostActions/PostActions.tsx
@@ -14,7 +14,7 @@ export function PostActions({
   onLike,
 }: PostActionsProps) {
   return (
-    <div className="border-border-base flex items-center justify-center border-y py-10">
+    <div className="flex items-center justify-end gap-3 py-6">
       <button
         type="button"
         onClick={onLike}
@@ -22,22 +22,30 @@ export function PostActions({
         aria-label={isLiked ? '좋아요 취소' : '좋아요'}
         aria-pressed={isLiked}
         className={[
-          'flex flex-col items-center gap-2 rounded-2xl border px-10 py-4 transition-colors duration-150 outline-none',
+          'flex items-center gap-1 rounded-full border px-4 py-2.5 text-xs transition-colors duration-150 outline-none',
           'focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2',
           isLiked
-            ? 'border-primary bg-primary-100 text-primary'
-            : 'border-border-base text-text-muted hover:border-primary hover:text-primary bg-white',
+            ? 'border-primary bg-primary-50 text-primary'
+            : 'hover:border-primary hover:text-primary border-gray-300 text-gray-500',
           !isLoggedIn ? 'cursor-not-allowed opacity-50' : '',
         ]
           .filter(Boolean)
           .join(' ')}
       >
-        <span className="text-3xl leading-none" aria-hidden="true">
-          {isLiked ? '♥' : '♡'}
-        </span>
-        <span className="text-sm font-medium">
-          {likeCount.toLocaleString()}
-        </span>
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
+        </svg>
+        <span className="font-normal">{likeCount.toLocaleString()}</span>
       </button>
     </div>
   )

--- a/src/components/community/PostAuthorActions/PostAuthorActions.tsx
+++ b/src/components/community/PostAuthorActions/PostAuthorActions.tsx
@@ -1,5 +1,3 @@
-import { Button } from '@/components/common/Button'
-
 export interface PostAuthorActionsProps {
   onEdit: () => void
   onDelete: () => void
@@ -10,13 +8,22 @@ export function PostAuthorActions({
   onDelete,
 }: PostAuthorActionsProps) {
   return (
-    <div className="flex items-center justify-end gap-2 pt-3">
-      <Button variant="secondary" size="sm" onClick={onEdit}>
+    <div className="flex items-center justify-end gap-0">
+      <button
+        type="button"
+        onClick={onEdit}
+        className="text-primary hover:bg-primary-50 rounded-sm px-4 py-2.5 text-base font-normal transition-colors"
+      >
         수정
-      </Button>
-      <Button variant="danger" size="sm" onClick={onDelete}>
+      </button>
+      <span className="inline-block h-6 w-px bg-gray-300" aria-hidden="true" />
+      <button
+        type="button"
+        onClick={onDelete}
+        className="rounded-sm px-4 py-2.5 text-base font-normal text-gray-500 transition-colors hover:bg-gray-100"
+      >
         삭제
-      </Button>
+      </button>
     </div>
   )
 }

--- a/src/components/community/PostAuthorActions/PostAuthorActions.tsx
+++ b/src/components/community/PostAuthorActions/PostAuthorActions.tsx
@@ -3,27 +3,29 @@ export interface PostAuthorActionsProps {
   onDelete: () => void
 }
 
+import { Button } from '@/components/common/Button'
+
 export function PostAuthorActions({
   onEdit,
   onDelete,
 }: PostAuthorActionsProps) {
   return (
     <div className="flex items-center justify-end gap-0">
-      <button
-        type="button"
+      <Button
+        variant="ghost"
         onClick={onEdit}
-        className="text-primary hover:bg-primary-50 rounded-sm px-4 py-2.5 text-base font-normal transition-colors"
+        className="text-primary hover:bg-primary-50 h-auto! rounded-sm! px-4! py-2.5! text-base! font-normal! transition-colors"
       >
         수정
-      </button>
+      </Button>
       <span className="inline-block h-6 w-px bg-gray-300" aria-hidden="true" />
-      <button
-        type="button"
+      <Button
+        variant="ghost"
         onClick={onDelete}
-        className="rounded-sm px-4 py-2.5 text-base font-normal text-gray-500 transition-colors hover:bg-gray-100"
+        className="h-auto! rounded-sm! px-4! py-2.5! text-base! font-normal! text-gray-500! transition-colors hover:bg-gray-100!"
       >
         삭제
-      </button>
+      </Button>
     </div>
   )
 }

--- a/src/components/community/PostAuthorActions/PostAuthorActions.tsx
+++ b/src/components/community/PostAuthorActions/PostAuthorActions.tsx
@@ -1,9 +1,9 @@
+import { Button } from '@/components/common/Button'
+
 export interface PostAuthorActionsProps {
   onEdit: () => void
   onDelete: () => void
 }
-
-import { Button } from '@/components/common/Button'
 
 export function PostAuthorActions({
   onEdit,

--- a/src/components/community/PostBody/PostBody.tsx
+++ b/src/components/community/PostBody/PostBody.tsx
@@ -44,7 +44,7 @@ export function PostBody({ content }: PostBodyProps) {
   return (
     <div
       className={[
-        'text-text-body min-h-40 py-8 text-base leading-relaxed',
+        'text-text-heading min-h-40 py-10 text-base leading-normal',
         /* 단락 */
         '[&_p]:mb-4',
         /* 제목 */

--- a/src/components/community/PostHeader/PostHeader.tsx
+++ b/src/components/community/PostHeader/PostHeader.tsx
@@ -1,5 +1,4 @@
 import { Avatar } from '@/components/common/Avatar'
-import { Badge } from '@/components/common/Badge'
 
 export interface PostHeaderProps {
   category: string
@@ -20,23 +19,31 @@ export function PostHeader({
   viewCount,
 }: PostHeaderProps) {
   return (
-    <div className="border-border-base flex flex-col gap-3 border-b pb-6">
-      <Badge variant="primary" size="sm">
-        {category}
-      </Badge>
+    <div className="flex flex-col gap-6">
+      {/* 카테고리 + 제목 + 프로필 */}
+      <div className="flex flex-col gap-6">
+        <span className="text-primary text-xl font-bold">{category}</span>
 
-      <h1 className="text-text-heading text-2xl leading-snug font-bold">
-        {title}
-      </h1>
-
-      <div className="text-text-muted flex items-center justify-between text-sm">
-        <div className="flex items-center gap-2">
-          <Avatar src={author.profileImage} alt={author.nickname} size="sm" />
-          <span className="text-text-body font-medium">{author.nickname}</span>
-          <span aria-hidden="true">·</span>
-          <span>{createdAt}</span>
+        <div className="flex items-start justify-between gap-6">
+          <h1 className="text-text-heading text-[32px] leading-snug font-bold">
+            {title}
+          </h1>
+          <div className="flex shrink-0 items-center gap-3">
+            <Avatar src={author.profileImage} alt={author.nickname} size="lg" />
+            <span className="text-base font-semibold text-gray-600">
+              {author.nickname}
+            </span>
+          </div>
         </div>
-        <span>조회 {viewCount.toLocaleString()}</span>
+      </div>
+
+      {/* 조회수 · 좋아요 · 시간 메타 정보 */}
+      <div className="flex items-center gap-1 text-base text-gray-400">
+        <span>조회수 {viewCount.toLocaleString()}</span>
+        <span className="text-disable" aria-hidden="true">
+          ·
+        </span>
+        <span>{createdAt}</span>
       </div>
     </div>
   )

--- a/src/components/community/PostHeader/PostHeader.tsx
+++ b/src/components/community/PostHeader/PostHeader.tsx
@@ -9,6 +9,20 @@ export interface PostHeaderProps {
   }
   createdAt: string
   viewCount: number
+  likeCount: number
+}
+
+function formatRelativeTime(isoString: string): string {
+  const diff = Date.now() - new Date(isoString).getTime()
+  const sec = Math.floor(diff / 1000)
+  const min = Math.floor(sec / 60)
+  const hour = Math.floor(min / 60)
+  const day = Math.floor(hour / 24)
+
+  if (sec < 60) return '방금 전'
+  if (min < 60) return `${min}분 전`
+  if (hour < 24) return `${hour}시간 전`
+  return `${day}일 전`
 }
 
 export function PostHeader({
@@ -17,6 +31,7 @@ export function PostHeader({
   author,
   createdAt,
   viewCount,
+  likeCount,
 }: PostHeaderProps) {
   return (
     <div className="flex flex-col gap-6">
@@ -40,10 +55,10 @@ export function PostHeader({
       {/* 조회수 · 좋아요 · 시간 메타 정보 */}
       <div className="flex items-center gap-1 text-base text-gray-400">
         <span>조회수 {viewCount.toLocaleString()}</span>
-        <span className="text-disable" aria-hidden="true">
-          ·
-        </span>
-        <span>{createdAt}</span>
+        <span aria-hidden="true">·</span>
+        <span>좋아요 {likeCount.toLocaleString()}</span>
+        <span aria-hidden="true">·</span>
+        <span>{formatRelativeTime(createdAt)}</span>
       </div>
     </div>
   )

--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -94,6 +94,15 @@ function CommunityDetailContent({ postId }: { postId: number }) {
     })
   }
 
+  const handleShare = async () => {
+    const url = window.location.href
+    if (navigator.share) {
+      await navigator.share({ url, title: post.title })
+    } else {
+      await navigator.clipboard.writeText(url)
+    }
+  }
+
   return (
     <main className="mx-auto w-full max-w-[944px] px-4 pt-16 pb-10">
       <article className="flex flex-col">
@@ -129,6 +138,7 @@ function CommunityDetailContent({ postId }: { postId: number }) {
           isLiked={isLiked}
           isLoggedIn={isLoggedIn}
           onLike={handleLike}
+          onShare={handleShare}
         />
 
         {/* 구분선 */}

--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -128,7 +128,7 @@ function CommunityDetailContent({ postId }: { postId: number }) {
         )}
 
         {/* 구분선 */}
-        <div className="mt-1 h-px w-full bg-gray-100" />
+        <div className="mt-1 h-px w-full bg-gray-200" />
 
         {/* 본문 (HTML · 이미지 포함) */}
         <PostBody content={post.content} />
@@ -143,7 +143,7 @@ function CommunityDetailContent({ postId }: { postId: number }) {
         />
 
         {/* 구분선 */}
-        <div className="h-px w-full bg-gray-100" />
+        <div className="h-px w-full bg-gray-200" />
 
         {/* 댓글 */}
         <CommunityCommentsPage postId={post.id} />

--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -95,18 +95,8 @@ function CommunityDetailContent({ postId }: { postId: number }) {
   }
 
   return (
-    <main className="mx-auto w-full max-w-[944px] px-4 py-10">
-      {/* 뒤로가기 */}
-      <button
-        type="button"
-        onClick={() => navigate('/community')}
-        className="text-text-muted hover:text-text-body mb-8 flex items-center gap-1.5 text-sm transition-colors"
-      >
-        <span aria-hidden="true">←</span>
-        커뮤니티 목록
-      </button>
-
-      <article>
+    <main className="mx-auto w-full max-w-[944px] px-4 pt-16 pb-10">
+      <article className="flex flex-col">
         {/* 헤더: 카테고리 · 제목 · 작성자 · 메타 */}
         <PostHeader
           category={post.category_name}
@@ -127,6 +117,9 @@ function CommunityDetailContent({ postId }: { postId: number }) {
           />
         )}
 
+        {/* 구분선 */}
+        <div className="mt-1 h-px w-full bg-gray-300" />
+
         {/* 본문 (HTML · 이미지 포함) */}
         <PostBody content={post.content} />
 
@@ -137,6 +130,9 @@ function CommunityDetailContent({ postId }: { postId: number }) {
           isLoggedIn={isLoggedIn}
           onLike={handleLike}
         />
+
+        {/* 구분선 */}
+        <div className="h-px w-full bg-gray-300" />
 
         {/* 댓글 */}
         <CommunityCommentsPage postId={post.id} />

--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -116,6 +116,7 @@ function CommunityDetailContent({ postId }: { postId: number }) {
           }}
           createdAt={post.created_at}
           viewCount={post.view_count}
+          likeCount={likeCount}
         />
 
         {/* 수정/삭제 버튼 — 작성자 전용 */}
@@ -127,7 +128,7 @@ function CommunityDetailContent({ postId }: { postId: number }) {
         )}
 
         {/* 구분선 */}
-        <div className="mt-1 h-px w-full bg-gray-300" />
+        <div className="mt-1 h-px w-full bg-gray-100" />
 
         {/* 본문 (HTML · 이미지 포함) */}
         <PostBody content={post.content} />
@@ -142,7 +143,7 @@ function CommunityDetailContent({ postId }: { postId: number }) {
         />
 
         {/* 구분선 */}
-        <div className="h-px w-full bg-gray-300" />
+        <div className="h-px w-full bg-gray-100" />
 
         {/* 댓글 */}
         <CommunityCommentsPage postId={post.id} />


### PR DESCRIPTION
## 관련 이슈

- closes #34

## 작업 내용

- 게시글 상세 페이지 Figma 디자인 반영
- 공유하기 버튼 구현

## 변경 사항

- `PostHeader`: 카테고리 텍스트 스타일, 제목 32px, Avatar lg, 메타 레이아웃
- `PostAuthorActions`: 수정(text-primary) / 삭제(text-gray-500) 텍스트 버튼, 세로 구분선
- `PostBody`: 본문 색상 text-text-heading, py-10
- `PostActions`: 좋아요 pill shape, 공유하기 버튼(링크 복사) 추가
- `CommunityDetailPage`: pt-16, 구분선 추가

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다

## 화면캡쳐
<img width="1511" height="847" alt="스크린샷 2026-04-29 오전 11 05 00" src="https://github.com/user-attachments/assets/e89e43ff-aaca-4504-93b3-d6fb1746c12e" />

