### PR TITLE
feat: CommunityEditPage 구현 (#10)

### DIFF
--- a/src/components/community/MarkdownEditor/MarkdownEditor.css
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.css
@@ -1,0 +1,193 @@
+/* ── MDEditor CSS 변수 오버라이드: 외부 border/shadow 제거 ── */
+.post-editor-wrap .w-md-editor {
+  --md-editor-box-shadow-color: transparent;
+  box-shadow: none !important;
+  border: none !important;
+  border-radius: 0 !important;
+  height: clamp(480px, 60vh, 760px) !important;
+  background-color: transparent !important;
+}
+
+/* ── 하단 리사이즈 핸들 제거 ── */
+.post-editor-wrap .w-md-editor-bar {
+  display: none !important;
+}
+
+/* ── 에디터 콘텐츠 영역 배경 ── */
+.post-editor-wrap .w-md-editor-content {
+  background-color: #ececec !important;
+  border-radius: 0 0 20px 20px !important;
+}
+
+/* ── 좌측 편집 패널 ── */
+.post-editor-wrap .w-md-editor-input {
+  background-color: #ffffff !important;
+}
+
+/* ── 우측 미리보기 패널 ── */
+.post-editor-wrap .w-md-editor-preview {
+  background-color: #fafafa !important;
+  box-shadow: inset 1px 0 0 0 #cdcdcd !important;
+}
+
+.post-editor-wrap .wmde-markdown {
+  background-color: #fafafa !important;
+}
+
+/* ── 툴바 전체 컨테이너 ── */
+.post-editor-wrap .w-md-editor-toolbar {
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: stretch !important;
+  justify-content: flex-start !important;
+  padding: 0 !important;
+  border-bottom: 1px solid #cdcdcd !important;
+  background-color: #ffffff !important;
+  border-radius: 20px 20px 0 0 !important;
+  overflow: visible !important;
+}
+
+/* Row 1 (commands UL), Row 2 (extraCommands UL) 각각 한 줄 전체 사용 */
+.post-editor-wrap .w-md-editor-toolbar > ul {
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: nowrap !important;
+  justify-content: center !important;
+  align-items: center !important;
+  width: 100% !important;
+  margin: 0 !important;
+  padding: 4px 8px !important;
+  list-style: none !important;
+  gap: 0 !important;
+  box-sizing: border-box !important;
+}
+
+/* 툴바 divider */
+.post-editor-wrap .w-md-editor-toolbar-divider {
+  background-color: #cdcdcd !important;
+  height: 16px !important;
+  width: 1px !important;
+  margin: 0 4px !important;
+}
+
+/* 툴바 버튼 */
+.post-editor-wrap .w-md-editor-toolbar li {
+  display: inline-flex !important;
+  align-items: center !important;
+  position: relative !important;
+}
+
+/* ── 드롭다운 자식 패널: 버튼 아래로 표시 ── */
+.post-editor-wrap .w-md-editor-toolbar-child {
+  top: 100% !important;
+  left: 0 !important;
+  margin-top: 4px !important;
+  z-index: 200 !important;
+}
+
+.post-editor-wrap .w-md-editor-toolbar li > button {
+  height: 28px !important;
+  min-width: 28px !important;
+  padding: 0 5px !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  border-radius: 4px !important;
+  font-size: 13px !important;
+  color: #52525b !important;
+}
+
+.post-editor-wrap .w-md-editor-toolbar li > button[data-inactive='true'] {
+  pointer-events: none !important;
+  opacity: 0.3 !important;
+}
+
+/* ── 헤딩 스타일 복원 ── */
+.post-editor-wrap .wmde-markdown h1 {
+  font-size: 2em !important;
+  font-weight: 700 !important;
+  margin: 0.67em 0 !important;
+  border-bottom: none !important;
+}
+.post-editor-wrap .wmde-markdown h2 {
+  font-size: 1.5em !important;
+  font-weight: 700 !important;
+  margin: 0.75em 0 !important;
+  border-bottom: none !important;
+}
+.post-editor-wrap .wmde-markdown h3 {
+  font-size: 1.25em !important;
+  font-weight: 600 !important;
+  margin: 0.83em 0 !important;
+}
+.post-editor-wrap .wmde-markdown h4 {
+  font-size: 1em !important;
+  font-weight: 600 !important;
+  margin: 1em 0 !important;
+}
+.post-editor-wrap .wmde-markdown h5 {
+  font-size: 0.875em !important;
+  font-weight: 600 !important;
+  margin: 1.17em 0 !important;
+}
+.post-editor-wrap .wmde-markdown h6 {
+  font-size: 0.85em !important;
+  font-weight: 600 !important;
+  margin: 1.33em 0 !important;
+  color: #6b7280 !important;
+}
+
+/* ── 드롭다운 팝업 ── */
+.toolbar-popup {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 4px;
+  width: max-content;
+  z-index: 200;
+}
+
+.toolbar-popup button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 5px 10px;
+  font-size: 13px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 4px;
+  white-space: nowrap;
+  color: #374151;
+}
+
+.toolbar-popup button:hover {
+  background: #f1f5f9;
+}
+
+/* ── 색상 팔레트 ── */
+.color-palette {
+  display: grid;
+  grid-template-columns: repeat(5, 22px);
+  gap: 3px;
+  padding: 7px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.color-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 3px;
+  cursor: pointer;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  transition: transform 0.1s;
+}
+
+.color-swatch:hover {
+  transform: scale(1.2);
+  border-color: #64748b;
+}

--- a/src/components/community/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.tsx
@@ -18,7 +18,7 @@ import {
   IndentIncrease,
   IndentDecrease,
 } from 'lucide-react'
-import '../PostForm/PostForm.css'
+import './MarkdownEditor.css'
 
 export interface MarkdownEditorProps {
   value: string

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -6,7 +6,7 @@ import { useNavigate, useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import type { AxiosError } from 'axios'
 import { ROUTES } from '@/constants/routes'
-// import { useAuthStore } from '@/stores/authStore'
+import { useAuthStore } from '@/stores/authStore'
 import { useCategories } from '@/features/posts/categories'
 import { postDetailQueryOptions } from '@/features/posts/detail'
 import { useUpdatePost } from '@/features/posts/edit'
@@ -31,13 +31,13 @@ export function CommunityEditPage() {
     variant: 'success',
   })
 
-  // const { isAuthenticated } = useAuthStore()
+  const { isAuthenticated } = useAuthStore()
 
-  // useEffect(() => {
-  //   if (!isAuthenticated) {
-  //     navigate(ROUTES.AUTH.LOGIN || '/login', { replace: true })
-  //   }
-  // }, [isAuthenticated, navigate])
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate(ROUTES.AUTH.LOGIN || '/login', { replace: true })
+    }
+  }, [isAuthenticated, navigate])
 
   const {
     data: categories = [],
@@ -92,7 +92,7 @@ export function CommunityEditPage() {
   }
 
   return (
-    <div className="mx-auto w-full px-4 py-8" style={{ maxWidth: '944px' }}>
+    <div className="mx-auto max-w-236 px-4 py-8">
       <PageHeader title="커뮤니티 게시글 수정" className="mb-8" />
       <PostForm
         mode="edit"

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -1,12 +1,14 @@
 /**
  * @figma 커뮤니티 - 게시글 수정하기  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-5757&m=dev
  */
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
 import type { AxiosError } from 'axios'
 import { ROUTES } from '@/constants/routes'
+// import { useAuthStore } from '@/stores/authStore'
 import { useCategories } from '@/features/posts/categories'
-import { usePostDetail } from '@/features/posts/detail'
+import { postDetailQueryOptions } from '@/features/posts/detail'
 import { useUpdatePost } from '@/features/posts/edit'
 import { Toast } from '@/components/common/Toast'
 import type { ToastVariant } from '@/components/common/Toast/Toast'
@@ -29,6 +31,8 @@ export function CommunityEditPage() {
     variant: 'success',
   })
 
+  // const { isAuthenticated } = useAuthStore()
+
   // useEffect(() => {
   //   if (!isAuthenticated) {
   //     navigate(ROUTES.AUTH.LOGIN || '/login', { replace: true })
@@ -41,15 +45,19 @@ export function CommunityEditPage() {
     isLoading: isCategoriesLoading,
   } = useCategories()
 
-  const { data: post, isLoading: isPostLoading } = usePostDetail(Number(postId))
+  const {
+    data: post,
+    isLoading: isPostLoading,
+    isError: isPostError,
+  } = useQuery(postDetailQueryOptions(Number(postId)))
 
   const { mutate: updatePost, isPending } = useUpdatePost(postId!)
 
-  // useEffect(() => {
-  //   if (isPostError) {
-  //     navigate(ROUTES.COMMUNITY.LIST, { replace: true })
-  //   }
-  // }, [isPostError, navigate])
+  useEffect(() => {
+    if (isPostError) {
+      navigate(ROUTES.COMMUNITY.LIST, { replace: true })
+    }
+  }, [isPostError, navigate])
 
   const handleSubmit = (values: PostFormSubmitValues) => {
     updatePost(values, {
@@ -84,8 +92,8 @@ export function CommunityEditPage() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl px-4 py-8">
-      <PageHeader title="게시글 수정" className="mb-8" />
+    <div className="mx-auto w-full px-4 py-8" style={{ maxWidth: '944px' }}>
+      <PageHeader title="커뮤니티 게시글 수정" className="mb-8" />
       <PostForm
         mode="edit"
         categories={categories}

--- a/src/pages/community/CommunityWritePage.tsx
+++ b/src/pages/community/CommunityWritePage.tsx
@@ -69,7 +69,7 @@ export function CommunityWritePage() {
   }
 
   return (
-    <div className="mx-auto w-full px-4 py-8" style={{ maxWidth: '944px' }}>
+    <div className="mx-auto max-w-236 px-4 py-8">
       <PageHeader title="커뮤니티 게시글 작성" className="mb-8" />
       <PostForm
         mode="write"


### PR DESCRIPTION
## 관련 이슈

- closes #10

## 작업 내용

- `CommunityEditPage` 수정 페이지 구현

## 변경 사항

- `usePostDetail(useSuspenseQuery)` → `useQuery(postDetailQueryOptions)` 교체 — Suspense 경계 없이도 동작하도록 수정
- `isPostError` 구조분해 추가 및 `useEffect`로 에러 시 목록 페이지 리다이렉트 처리
- 컨테이너 너비 `max-w-3xl` → `944px` (WritePage와 동일하게 통일)
- `PageHeader` 타이틀 `'게시글 수정'` → `'커뮤니티 게시글 수정'`
- 인증 체크 주석 처리 (WritePage와 동일하게 개발 중 비활성화)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다