### PR TITLE
fix: isAuthor 권한 검증 id 기반 비교로 수정 (#51)

### DIFF
--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -64,7 +64,7 @@ function CommunityDetailContent({ postId }: { postId: number }) {
   const { data: post } = usePostDetail(postId)
   const { isAuthenticated, user } = useAuthStore()
 
-  const isAuthor = isAuthenticated && user?.nickname === post.author.nickname
+  const isAuthor = isAuthenticated && user?.id === post.author.id
 
   const [isLiked, setIsLiked] = useState(post.is_liked ?? false)
   const [likeCount, setLikeCount] = useState(post.like_count)

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 interface User {
+  id: number
   nickname: string
   email: string
   profileImage?: string | null


### PR DESCRIPTION
## 관련 이슈

- closes #51

## 문제

`isAuthor` 판별 시 nickname(변경 가능한 값)으로 비교해 권한 우회 가능.

## 수정 내용

- `authStore`의 `User` 인터페이스에 `id: number` 필드 추가
- `CommunityDetailPage`의 `isAuthor` 비교 로직을 `user?.id === post.author.id`로 변경

## 변경 파일

- `src/stores/authStore.ts` — `User.id: number` 추가
- `src/pages/community/CommunityDetailPage.tsx` — `isAuthor` 비교 기준 수정

## 체크리스트

- [x] 타입 에러 없음 (tsc --noEmit)
- [x] 빌드 성공 (pnpm build)
- [x] 기존 기능 영향 없음