### PR TITLE
fix: ConfirmModal 비동기 처리 개선 (#53)

### DIFF
--- a/src/components/common/Modal/ConfirmModal.tsx
+++ b/src/components/common/Modal/ConfirmModal.tsx
@@ -12,6 +12,13 @@ export interface ConfirmModalProps {
   danger?: boolean
   /** 요청 중 확인 버튼 비활성화 (중복 클릭 방지) */
   isConfirmDisabled?: boolean
+  /**
+   * false이면 확인 클릭 후 모달을 닫지 않음.
+   * 비동기 작업 완료 후 부모가 직접 onClose를 호출해야 함. (기본값: true)
+   */
+  closeOnConfirm?: boolean
+  /** 요청 중 취소 버튼 비활성화 — race condition 방지 */
+  isCancelDisabled?: boolean
 }
 
 /** Figma 1:3271 — 본문 + 취소/확인 pill 버튼 */
@@ -25,6 +32,8 @@ export function ConfirmModal({
   onConfirm,
   danger = false,
   isConfirmDisabled = false,
+  closeOnConfirm = true,
+  isCancelDisabled = false,
 }: ConfirmModalProps) {
   const handleCancel = () => {
     onCancel?.()
@@ -33,7 +42,7 @@ export function ConfirmModal({
 
   const handleConfirm = () => {
     onConfirm?.()
-    onClose()
+    if (closeOnConfirm) onClose()
   }
 
   return (
@@ -47,7 +56,8 @@ export function ConfirmModal({
         <div className="flex items-center justify-end gap-3">
           <button
             onClick={handleCancel}
-            className="bg-primary-100 text-primary-800 hover:bg-primary-200 focus-visible:ring-primary h-[42px] rounded-full px-6 text-base font-semibold tracking-tight transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+            disabled={isCancelDisabled}
+            className="bg-primary-100 text-primary-800 hover:bg-primary-200 focus-visible:ring-primary h-[42px] rounded-full px-6 text-base font-semibold tracking-tight transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {cancelLabel}
           </button>

--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -122,7 +122,7 @@ function CommunityDetailContent({ postId }: { postId: number }) {
     if (isDeletePending) return
     deletePost(postId, {
       onSuccess: () => {
-        setIsDeleteModalOpen(false) // 모달 즉시 닫기
+        setIsDeleteModalOpen(false)
         showToast('게시글이 삭제되었습니다.', 'success')
         setTimeout(() => navigate('/community'), 1500)
       },
@@ -198,11 +198,15 @@ function CommunityDetailContent({ postId }: { postId: number }) {
       {/* 게시글 삭제 확인 모달 */}
       <ConfirmModal
         isOpen={isDeleteModalOpen}
-        onClose={() => setIsDeleteModalOpen(false)}
+        onClose={() => {
+          if (!isDeletePending) setIsDeleteModalOpen(false)
+        }}
         message={`게시글을 삭제하시겠습니까?\n삭제된 게시글은 복구할 수 없습니다.`}
         confirmLabel="삭제"
         danger
+        closeOnConfirm={false}
         isConfirmDisabled={isDeletePending}
+        isCancelDisabled={isDeletePending}
         onConfirm={handleDeleteConfirm}
       />
 


### PR DESCRIPTION
## 관련 이슈

- closes #53

## 작업 내용

- `ConfirmModal`에 `closeOnConfirm` prop 추가 — `false`이면 확인 클릭 후 모달을 닫지 않고 부모가 비동기 완료 시점에 직접 닫음
- `ConfirmModal`에 `isCancelDisabled` prop 추가 — 삭제 진행 중 취소 버튼 비활성화로 race condition 방지
- `CommunityDetailPage`: `onClose`에 `isDeletePending` 가드 추가 — 삭제 중 overlay 클릭·Escape로 모달이 닫히는 문제 해결
- 기존 호출부(default `closeOnConfirm=true`)는 동작 변경 없음

## 변경 사항

| 파일 | 변경 내용 |
|------|-----------|
| `src/components/common/Modal/ConfirmModal.tsx` | `closeOnConfirm`, `isCancelDisabled` prop 추가 |
| `src/pages/community/CommunityDetailPage.tsx` | `closeOnConfirm={false}`, `isCancelDisabled`, `onClose` 가드 적용 |

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다