### PR TITLE
fix: 마크다운 에디터 서식 렌더링 및 툴바 UX 개선 (#58)

### DIFF
--- a/.claude/hooks/check-pnpm-before-git.sh
+++ b/.claude/hooks/check-pnpm-before-git.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# git pull / push 전에 pnpm 관련 파일이 있으면 차단하고, 없으면 확인을 요청합니다.
+
+cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# git pull 또는 git push 가 아니면 그냥 통과
+echo "$cmd" | grep -qE '^git (pull|push)( |$)' || exit 0
+
+# pnpm 관련 파일 탐색 (node_modules 제외, 최대 3단계)
+pnpm_files=$(find . -maxdepth 3 \( \
+  -name "pnpm-lock.yaml" \
+  -o -name ".pnpmfile.cjs" \
+  -o -name "pnpm-workspace.yaml" \
+\) ! -path "*/node_modules/*" 2>/dev/null | sort | tr '\n' ' ')
+
+if [ -n "$pnpm_files" ]; then
+  jq -nc --arg cmd "$cmd" --arg files "$pnpm_files" \
+    '{"continue": false, "stopReason": ("⛔ pnpm 관련 파일이 남아있습니다: " + $files + "— 정리 후 다시 시도하세요.")}'
+else
+  jq -nc --arg cmd "$cmd" \
+    '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "ask", "permissionDecisionReason": ("✅ pnpm 파일 없음 확인됨. \"" + $cmd + "\" 을 진행할까요?")}}'
+fi

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,7 @@
 {
   "permissions": {
     "allow": [
-      "Bash(pnpm add:*)",
+      "Bash(npm install *)",
       "Bash(npx playwright:*)",
       "Bash(git:*)",
       "Bash(gh pr:*)",
@@ -10,7 +10,7 @@
       "mcp__plugin_context7_context7__resolve-library-id",
       "mcp__plugin_context7_context7__query-docs",
       "Bash(npx msw:*)",
-      "Bash(pnpm build:*)",
+      "Bash(npm run build)",
       "mcp__context7__query-docs",
       "Bash(npm install:*)",
       "Bash(npx husky:*)",
@@ -27,6 +27,21 @@
       "Bash(pnpm lint:*)",
       "Bash(npx eslint:*)",
       "Skill(git-sync)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-pnpm-before-git.sh",
+            "timeout": 10,
+            "statusMessage": "pnpm 파일 확인 중..."
+          }
+        ]
+      }
     ]
   },
   "enabledMcpjsonServers": [

--- a/src/components/community/MarkdownEditor/MarkdownEditor.css
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.css
@@ -102,6 +102,14 @@
   opacity: 0.3 !important;
 }
 
+/* ── Tab 들여쓰기로 생성된 인덴티드 코드블록 배경 제거 ── */
+/* pre:not([class]) = 언어 미지정 코드블록 (4칸 들여쓰기 또는 언어 없는 펜싱) */
+.post-editor-wrap .wmde-markdown pre:not([class]) {
+  background-color: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
 /* ── 헤딩 스타일 복원 ── */
 .post-editor-wrap .wmde-markdown h1 {
   font-size: 2em !important;

--- a/src/components/community/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.tsx
@@ -109,6 +109,7 @@ const fontFamilyCommand: ICommand = {
           key={value}
           type="button"
           style={{ fontFamily: value === 'inherit' ? undefined : value }}
+          onMouseDown={(e) => e.preventDefault()}
           onClick={() => {
             const inner = safeSelected(getState)
             textApi?.replaceSelection(
@@ -141,6 +142,7 @@ const fontSizeCommand: ICommand = {
         <button
           key={size}
           type="button"
+          onMouseDown={(e) => e.preventDefault()}
           onClick={() => {
             const inner = safeSelected(getState)
             textApi?.replaceSelection(
@@ -200,24 +202,83 @@ function makeColorCommand(
   }
 }
 
-const bgColorCommand = makeColorCommand(
-  'bg-color',
-  '배경색',
-  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-    <span
-      style={{
-        width: 16,
-        height: 16,
-        borderRadius: 3,
-        background: '#4285f4',
-        border: '1px solid rgba(0,0,0,0.12)',
-        display: 'inline-block',
-      }}
-    />
-    <ChevronDown size={10} />
-  </span>,
-  (color, text) => `<mark style="background-color: ${color}">${text}</mark>`
-)
+const BG_PALETTE_COLORS = ['#ffffff', ...PALETTE_COLORS]
+
+const bgColorCommand: ICommand = {
+  name: 'bg-color',
+  keyCommand: 'group',
+  groupName: 'bg-color',
+  buttonProps: { 'aria-label': '배경색', title: '배경색' },
+  icon: (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+      <span
+        style={{
+          width: 16,
+          height: 16,
+          borderRadius: 3,
+          background: '#4285f4',
+          border: '1px solid rgba(0,0,0,0.12)',
+          display: 'inline-block',
+        }}
+      />
+      <ChevronDown size={10} />
+    </span>
+  ),
+  children: ({ close, getState, textApi }) => (
+    <div style={{ padding: 7 }}>
+      <button
+        type="button"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => {
+          const selected = safeSelected(getState)
+          textApi?.replaceSelection(
+            selected.replace(/<mark[^>]*>([\s\S]*?)<\/mark>/g, '$1')
+          )
+          close()
+        }}
+        style={{
+          display: 'block',
+          width: '100%',
+          textAlign: 'center',
+          padding: '4px 8px',
+          marginBottom: 6,
+          fontSize: 12,
+          cursor: 'pointer',
+          border: '1px solid #e2e8f0',
+          borderRadius: 4,
+          background: 'transparent',
+          color: '#374151',
+        }}
+      >
+        배경색 제거
+      </button>
+      <div className="color-palette" style={{ padding: 0 }}>
+        {BG_PALETTE_COLORS.map((color) => (
+          <div
+            key={color}
+            className="color-swatch"
+            style={{
+              background: color,
+              border:
+                color === '#ffffff'
+                  ? '1px solid #d1d5db'
+                  : '1px solid rgba(0,0,0,0.12)',
+            }}
+            title={color}
+            onClick={() => {
+              const selected = safeSelected(getState)
+              textApi?.replaceSelection(
+                `<mark style="background-color: ${color}">${selected}</mark>`
+              )
+              close()
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  ),
+  execute: () => {},
+}
 
 const textColorCommand = makeColorCommand(
   'text-color',
@@ -304,6 +365,7 @@ const listDropdownCmd: ICommand = {
     <div className="toolbar-popup">
       <button
         type="button"
+        onMouseDown={(e) => e.preventDefault()}
         onClick={() => {
           const text = safeSelected(getState)
           const lines = text
@@ -320,6 +382,7 @@ const listDropdownCmd: ICommand = {
       </button>
       <button
         type="button"
+        onMouseDown={(e) => e.preventDefault()}
         onClick={() => {
           const text = safeSelected(getState)
           const lines = text
@@ -336,6 +399,7 @@ const listDropdownCmd: ICommand = {
       </button>
       <button
         type="button"
+        onMouseDown={(e) => e.preventDefault()}
         onClick={() => {
           const text = safeSelected(getState)
           const lines = text
@@ -367,6 +431,7 @@ const lineHeightCmd: ICommand = {
         <button
           key={h}
           type="button"
+          onMouseDown={(e) => e.preventDefault()}
           onClick={() => {
             const text = safeSelected(getState)
             textApi?.replaceSelection(
@@ -421,6 +486,7 @@ const clearFormatCmd: ICommand = {
   buttonProps: { 'aria-label': '서식 제거', title: '서식 제거' },
   icon: <RemoveFormatting size={14} />,
   execute: (state, api) => {
+    if (!state.selectedText) return
     const cleaned = state.selectedText
       .replace(/\*\*(.*?)\*\*/gs, '$1')
       .replace(/\*(.*?)\*/gs, '$1')

--- a/src/components/community/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.tsx
@@ -252,7 +252,7 @@ const alignLeftCommand: ICommand = {
   icon: <AlignLeft size={14} />,
   execute: (state, api) =>
     api.replaceSelection(
-      `<div style="text-align: left">${state.selectedText}</div>`
+      `<span style="display: block; text-align: left">${state.selectedText}</span>`
     ),
 }
 
@@ -263,7 +263,7 @@ const alignCenterCommand: ICommand = {
   icon: <AlignCenter size={14} />,
   execute: (state, api) =>
     api.replaceSelection(
-      `<div style="text-align: center">${state.selectedText}</div>`
+      `<span style="display: block; text-align: center">${state.selectedText}</span>`
     ),
 }
 
@@ -274,7 +274,7 @@ const alignRightCommand: ICommand = {
   icon: <AlignRight size={14} />,
   execute: (state, api) =>
     api.replaceSelection(
-      `<div style="text-align: right">${state.selectedText}</div>`
+      `<span style="display: block; text-align: right">${state.selectedText}</span>`
     ),
 }
 
@@ -285,7 +285,7 @@ const alignJustifyCommand: ICommand = {
   icon: <AlignJustify size={14} />,
   execute: (state, api) =>
     api.replaceSelection(
-      `<div style="text-align: justify">${state.selectedText}</div>`
+      `<span style="display: block; text-align: justify">${state.selectedText}</span>`
     ),
 }
 
@@ -370,7 +370,7 @@ const lineHeightCmd: ICommand = {
           onClick={() => {
             const text = safeSelected(getState)
             textApi?.replaceSelection(
-              `<div style="line-height: ${h}">${text}</div>`
+              `<span style="display: block; line-height: ${h}">${text}</span>`
             )
             close()
           }}


### PR DESCRIPTION
## 관련 이슈

- closes #58

## 작업 내용

- 정렬·줄간격 커맨드의 `<div>` 태그를 `<span style="display: block">` 으로 교체
- 툴바 드롭다운 버튼에 `onMouseDown preventDefault` 추가
- 배경색 팔레트에 흰색 스와치 및 배경색 제거 버튼 추가
- 선택 영역 없을 때 서식 제거 커맨드 조기 반환 처리
- git pull/push 전 pnpm 파일 감지 PreToolUse 훅 추가

## 변경 사항

- `src/components/community/MarkdownEditor/MarkdownEditor.tsx` — 정렬/줄간격 div→span, 팔레트 확장, clearFormat 가드
- `src/components/community/MarkdownEditor/MarkdownEditor.css` — 인덴티드 코드블록 배경 제거
- `.claude/hooks/check-pnpm-before-git.sh` — pnpm 감지 훅 스크립트
- `.claude/settings.local.json` — PreToolUse 훅 등록

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)