### PR TITLE
feat: 마크다운 에디터 기능 개선 및 커뮤니티 게시글 기능 업데이트 (#64)

### DIFF
--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -45,7 +45,7 @@ export function CommunityComments({ postId }: Props) {
     isLoading,
     isError,
     error,
-  } = useCommentsInfiniteQuery(postId, Boolean(postId))
+  } = useCommentsInfiniteQuery(postId, Boolean(postId), sortOrder)
 
   const queryClient = useQueryClient()
   const { mutate: submitComment, isPending: isSubmitting } =

--- a/src/components/community/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.tsx
@@ -7,6 +7,7 @@ import {
   Undo2,
   Redo2,
   Underline,
+  Strikethrough,
   AlignLeft,
   AlignCenter,
   AlignRight,
@@ -68,6 +69,36 @@ const PALETTE_COLORS = [
   '#c27ba0',
 ]
 
+interface EditorFullState {
+  text: string
+  selectedText: string
+  selection: { start: number; end: number }
+}
+
+// 정렬 span 제거: 이미 적용된 text-align span을 벗겨냄
+function stripAlignSpan(text: string): string {
+  return text.replace(
+    /^<span style="display: block; text-align: (?:left|center|right|justify)">([\s\S]*)<\/span>$/,
+    '$1'
+  )
+}
+
+// 줄간격 span 제거
+function stripLineHeightSpan(text: string): string {
+  return text.replace(
+    /^<span style="display: block; line-height: [\d.]+">([\s\S]*)<\/span>$/,
+    '$1'
+  )
+}
+
+// 언더라인 토글: 이미 <u>로 감싸져 있으면 제거, 아니면 추가
+function toggleUnderline(text: string): string {
+  if (/^<u>[\s\S]*<\/u>$/.test(text)) {
+    return text.replace(/^<u>([\s\S]*)<\/u>$/, '$1')
+  }
+  return `<u>${text}</u>`
+}
+
 const PILL: React.CSSProperties = {
   borderRadius: 6,
   background: '#f0f2f5',
@@ -112,8 +143,12 @@ const fontFamilyCommand: ICommand = {
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => {
             const inner = safeSelected(getState)
+            const stripped = inner.replace(
+              /^<span style="font-family: [^"]*">([\s\S]*)<\/span>$/,
+              '$1'
+            )
             textApi?.replaceSelection(
-              `<span style="font-family: ${value}">${inner}</span>`
+              `<span style="font-family: ${value}">${stripped}</span>`
             )
             close()
           }}
@@ -145,8 +180,12 @@ const fontSizeCommand: ICommand = {
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => {
             const inner = safeSelected(getState)
+            const stripped = inner.replace(
+              /^<span style="font-size: \d+px">([\s\S]*)<\/span>$/,
+              '$1'
+            )
             textApi?.replaceSelection(
-              `<span style="font-size: ${size}px">${inner}</span>`
+              `<span style="font-size: ${size}px">${stripped}</span>`
             )
             close()
           }}
@@ -165,41 +204,24 @@ const underlineCommand: ICommand = {
   buttonProps: { 'aria-label': '밑줄', title: '밑줄' },
   icon: <Underline size={14} />,
   execute: (state, api) => {
-    api.replaceSelection(`<u>${state.selectedText}</u>`)
+    api.replaceSelection(toggleUnderline(state.selectedText))
   },
 }
 
-function makeColorCommand(
-  name: string,
-  label: string,
-  icon: React.ReactElement,
-  wrap: (color: string, text: string) => string
-): ICommand {
-  return {
-    name,
-    keyCommand: 'group',
-    groupName: name,
-    buttonProps: { 'aria-label': label, title: label },
-    icon,
-    children: ({ close, getState, textApi }) => (
-      <div className="color-palette">
-        {PALETTE_COLORS.map((color) => (
-          <div
-            key={color}
-            className="color-swatch"
-            style={{ background: color }}
-            title={color}
-            onClick={() => {
-              const selected = safeSelected(getState)
-              textApi?.replaceSelection(wrap(color, selected))
-              close()
-            }}
-          />
-        ))}
-      </div>
-    ),
-    execute: () => {},
-  }
+// ~~markdown~~ 대신 <del> HTML을 사용 — markdown 취소선은 HTML 태그와 섞이면 파서가 깨짐
+const strikethroughCommand: ICommand = {
+  name: 'strikethrough',
+  keyCommand: 'strikethrough',
+  buttonProps: { 'aria-label': '취소선', title: '취소선' },
+  icon: <Strikethrough size={14} />,
+  execute: (state, api) => {
+    const sel = state.selectedText
+    if (/^<del>[\s\S]*<\/del>$/.test(sel)) {
+      api.replaceSelection(sel.replace(/^<del>([\s\S]*)<\/del>$/, '$1'))
+    } else {
+      api.replaceSelection(`<del>${sel}</del>`)
+    }
+  },
 }
 
 const BG_PALETTE_COLORS = ['#ffffff', ...PALETTE_COLORS]
@@ -266,10 +288,34 @@ const bgColorCommand: ICommand = {
             }}
             title={color}
             onClick={() => {
-              const selected = safeSelected(getState)
-              textApi?.replaceSelection(
-                `<mark style="background-color: ${color}">${selected}</mark>`
+              const state = getState?.() as false | EditorFullState | undefined
+              if (!state) {
+                close?.()
+                return
+              }
+              const { text, selectedText, selection } = state
+              const before = text.substring(0, selection.start)
+              const after = text.substring(selection.end)
+              // 선택 영역이 이미 mark 태그 안에 있는 경우: 선택을 mark 전체로 확장 후 교체
+              const beforeMark = before.match(
+                /<mark style="background-color: [^"]*">$/
               )
+              const afterMark = after.match(/^<\/mark>/)
+              if (beforeMark && afterMark) {
+                textApi?.setSelectionRange({
+                  start: selection.start - beforeMark[0].length,
+                  end: selection.end + afterMark[0].length,
+                })
+                textApi?.replaceSelection(
+                  `<mark style="background-color: ${color}">${selectedText}</mark>`
+                )
+              } else {
+                // 선택 안에 mark 태그가 포함된 경우: 모두 벗기고 새 색상 적용
+                const stripped = selectedText.replace(/<\/?mark[^>]*>/g, '')
+                textApi?.replaceSelection(
+                  `<mark style="background-color: ${color}">${stripped}</mark>`
+                )
+              }
               close()
             }}
           />
@@ -280,41 +326,101 @@ const bgColorCommand: ICommand = {
   execute: () => {},
 }
 
-const textColorCommand = makeColorCommand(
-  'text-color',
-  '글자색',
-  <span
-    style={{
-      display: 'inline-flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      gap: 2,
-      lineHeight: 1,
-    }}
-  >
-    <span style={{ fontWeight: 700, fontSize: 13 }}>A</span>
+const TEXT_COLOR_SPAN_RE = /^<span style="color: [^"]*">$/
+
+const textColorCommand: ICommand = {
+  name: 'text-color',
+  keyCommand: 'group',
+  groupName: 'text-color',
+  buttonProps: { 'aria-label': '글자색', title: '글자색' },
+  icon: (
     <span
       style={{
-        width: 14,
-        height: 3,
-        background: '#e53e3e',
-        borderRadius: 1,
-        display: 'block',
+        display: 'inline-flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 2,
+        lineHeight: 1,
       }}
-    />
-  </span>,
-  (color, text) => `<span style="color: ${color}">${text}</span>`
-)
+    >
+      <span style={{ fontWeight: 700, fontSize: 13 }}>A</span>
+      <span
+        style={{
+          width: 14,
+          height: 3,
+          background: '#e53e3e',
+          borderRadius: 1,
+          display: 'block',
+        }}
+      />
+    </span>
+  ),
+  children: ({ close, getState, textApi }) => (
+    <div className="color-palette">
+      {PALETTE_COLORS.map((color) => (
+        <div
+          key={color}
+          className="color-swatch"
+          style={{ background: color }}
+          title={color}
+          onClick={() => {
+            const state = getState?.() as false | EditorFullState | undefined
+            if (!state) {
+              close?.()
+              return
+            }
+            const { text, selectedText, selection } = state
+            const before = text.substring(0, selection.start)
+            const after = text.substring(selection.end)
+            // 선택 영역이 color span 안에 있는 경우: span 전체로 확장 후 교체
+            const beforeSpan = before.match(/<span style="color: [^"]*">$/)
+            const afterSpan = after.match(/^<\/span>/)
+            if (
+              beforeSpan &&
+              TEXT_COLOR_SPAN_RE.test(beforeSpan[0]) &&
+              afterSpan
+            ) {
+              textApi?.setSelectionRange({
+                start: selection.start - beforeSpan[0].length,
+                end: selection.end + afterSpan[0].length,
+              })
+              textApi?.replaceSelection(
+                `<span style="color: ${color}">${selectedText}</span>`
+              )
+            } else {
+              // 선택 안에 color span이 있는 경우: 모두 벗기고 새 색상 적용
+              const stripped = selectedText.replace(
+                /<span style="color: [^"]*">([\s\S]*?)<\/span>/g,
+                '$1'
+              )
+              textApi?.replaceSelection(
+                `<span style="color: ${color}">${stripped}</span>`
+              )
+            }
+            close()
+          }}
+        />
+      ))}
+    </div>
+  ),
+  execute: () => {},
+}
 
 const alignLeftCommand: ICommand = {
   name: 'align-left',
   keyCommand: 'align-left',
   buttonProps: { 'aria-label': '왼쪽 정렬', title: '왼쪽 정렬' },
   icon: <AlignLeft size={14} />,
-  execute: (state, api) =>
-    api.replaceSelection(
-      `<span style="display: block; text-align: left">${state.selectedText}</span>`
-    ),
+  execute: (state, api) => {
+    const sel = state.selectedText
+    if (/^<span style="display: block; text-align: left">/.test(sel)) {
+      api.replaceSelection(stripAlignSpan(sel))
+    } else {
+      api.replaceSelection(
+        `<span style="display: block; text-align: left">${stripAlignSpan(sel)}</span>`
+      )
+    }
+  },
 }
 
 const alignCenterCommand: ICommand = {
@@ -322,10 +428,16 @@ const alignCenterCommand: ICommand = {
   keyCommand: 'align-center',
   buttonProps: { 'aria-label': '가운데 정렬', title: '가운데 정렬' },
   icon: <AlignCenter size={14} />,
-  execute: (state, api) =>
-    api.replaceSelection(
-      `<span style="display: block; text-align: center">${state.selectedText}</span>`
-    ),
+  execute: (state, api) => {
+    const sel = state.selectedText
+    if (/^<span style="display: block; text-align: center">/.test(sel)) {
+      api.replaceSelection(stripAlignSpan(sel))
+    } else {
+      api.replaceSelection(
+        `<span style="display: block; text-align: center">${stripAlignSpan(sel)}</span>`
+      )
+    }
+  },
 }
 
 const alignRightCommand: ICommand = {
@@ -333,10 +445,16 @@ const alignRightCommand: ICommand = {
   keyCommand: 'align-right',
   buttonProps: { 'aria-label': '오른쪽 정렬', title: '오른쪽 정렬' },
   icon: <AlignRight size={14} />,
-  execute: (state, api) =>
-    api.replaceSelection(
-      `<span style="display: block; text-align: right">${state.selectedText}</span>`
-    ),
+  execute: (state, api) => {
+    const sel = state.selectedText
+    if (/^<span style="display: block; text-align: right">/.test(sel)) {
+      api.replaceSelection(stripAlignSpan(sel))
+    } else {
+      api.replaceSelection(
+        `<span style="display: block; text-align: right">${stripAlignSpan(sel)}</span>`
+      )
+    }
+  },
 }
 
 const alignJustifyCommand: ICommand = {
@@ -344,10 +462,16 @@ const alignJustifyCommand: ICommand = {
   keyCommand: 'align-justify',
   buttonProps: { 'aria-label': '양쪽 정렬', title: '양쪽 정렬' },
   icon: <AlignJustify size={14} />,
-  execute: (state, api) =>
-    api.replaceSelection(
-      `<span style="display: block; text-align: justify">${state.selectedText}</span>`
-    ),
+  execute: (state, api) => {
+    const sel = state.selectedText
+    if (/^<span style="display: block; text-align: justify">/.test(sel)) {
+      api.replaceSelection(stripAlignSpan(sel))
+    } else {
+      api.replaceSelection(
+        `<span style="display: block; text-align: justify">${stripAlignSpan(sel)}</span>`
+      )
+    }
+  },
 }
 
 const listDropdownCmd: ICommand = {
@@ -434,8 +558,9 @@ const lineHeightCmd: ICommand = {
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => {
             const text = safeSelected(getState)
+            const stripped = stripLineHeightSpan(text)
             textApi?.replaceSelection(
-              `<span style="display: block; line-height: ${h}">${text}</span>`
+              `<span style="display: block; line-height: ${h}">${stripped}</span>`
             )
             close()
           }}
@@ -490,7 +615,6 @@ const clearFormatCmd: ICommand = {
     const cleaned = state.selectedText
       .replace(/\*\*(.*?)\*\*/gs, '$1')
       .replace(/\*(.*?)\*/gs, '$1')
-      .replace(/~~(.*?)~~/gs, '$1')
       .replace(/<[^>]+>/gs, '')
     api.replaceSelection(cleaned)
   },
@@ -637,7 +761,7 @@ export function MarkdownEditor({
       mdCommands.bold,
       mdCommands.italic,
       underlineCommand,
-      mdCommands.strikethrough,
+      strikethroughCommand,
       bgColorCommand,
       textColorCommand,
       mdCommands.divider,
@@ -672,6 +796,25 @@ export function MarkdownEditor({
           preview="live"
           commands={editorCommands}
           extraCommands={editorExtraCommands}
+          textareaProps={{
+            onKeyDown: (e) => {
+              if (e.shiftKey && e.key === 'Enter') {
+                e.preventDefault()
+                const textarea = e.currentTarget
+                const start = textarea.selectionStart
+                const end = textarea.selectionEnd
+                const insert = '<br>\n'
+                const current = textarea.value
+                const next =
+                  current.substring(0, start) + insert + current.substring(end)
+                handleChange(next)
+                requestAnimationFrame(() => {
+                  textarea.selectionStart = start + insert.length
+                  textarea.selectionEnd = start + insert.length
+                })
+              }
+            },
+          }}
         />
       </div>
       {isUploading && (

--- a/src/components/community/PostBody/PostBody.tsx
+++ b/src/components/community/PostBody/PostBody.tsx
@@ -1,73 +1,83 @@
 import DOMPurify from 'dompurify'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
 
 export interface PostBodyProps {
   /**
-   * HTML 문자열 (리치텍스트 에디터 출력)
-   * 이미지, 제목, 목록, 인용구 등 포함 가능
+   * 마크다운 + 인라인 HTML 혼합 문자열 (리치텍스트 에디터 출력)
    */
   content: string
 }
 
-const ALLOWED_TAGS = [
-  'p',
-  'br',
-  'b',
-  'i',
-  'em',
-  'strong',
-  'a',
-  'ul',
-  'ol',
-  'li',
-  'h1',
-  'h2',
-  'h3',
-  'blockquote',
-  'pre',
-  'code',
-  'img',
-  'hr',
-  'span',
-  'div',
-]
-
-const ALLOWED_ATTR = ['href', 'src', 'alt', 'class', 'target', 'rel']
-
-function sanitizeHtml(html: string): string {
-  return DOMPurify.sanitize(html, {
-    ALLOWED_TAGS,
-    ALLOWED_ATTR,
-  })
+const SANITIZE_OPTIONS = {
+  ALLOWED_TAGS: [
+    'p',
+    'br',
+    'b',
+    'i',
+    'em',
+    'strong',
+    'u',
+    'a',
+    'ul',
+    'ol',
+    'li',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'blockquote',
+    'pre',
+    'code',
+    'img',
+    'hr',
+    'span',
+    'div',
+    'mark',
+    'del',
+    's',
+    'table',
+    'thead',
+    'tbody',
+    'tr',
+    'th',
+    'td',
+  ],
+  ALLOWED_ATTR: ['href', 'src', 'alt', 'class', 'target', 'rel', 'style'],
 }
 
 export function PostBody({ content }: PostBodyProps) {
+  const safe = DOMPurify.sanitize(content, SANITIZE_OPTIONS) as string
+
   return (
     <div
       className={[
-        'text-text-heading min-h-40 py-10 text-base leading-normal',
-        /* 단락 */
-        '[&_p]:mb-4',
-        /* 제목 */
+        'text-text-heading min-h-40 py-10 text-base leading-relaxed',
+        '[&_p]:mb-3',
         '[&_h1]:text-text-heading [&_h1]:mb-4 [&_h1]:text-2xl [&_h1]:font-bold',
         '[&_h2]:text-text-heading [&_h2]:mb-3 [&_h2]:text-xl [&_h2]:font-bold',
         '[&_h3]:text-text-heading [&_h3]:mb-2 [&_h3]:text-lg [&_h3]:font-semibold',
-        /* 목록 */
         '[&_ul]:mb-4 [&_ul]:list-disc [&_ul]:pl-6',
         '[&_ol]:mb-4 [&_ol]:list-decimal [&_ol]:pl-6',
         '[&_li]:mb-1',
-        /* 인용구 */
         '[&_blockquote]:border-primary [&_blockquote]:text-text-muted [&_blockquote]:my-4 [&_blockquote]:border-l-4 [&_blockquote]:pl-4',
-        /* 이미지 */
         '[&_img]:my-4 [&_img]:max-w-full [&_img]:rounded-lg',
-        /* 링크 */
         '[&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2',
-        /* 코드 */
         '[&_pre]:bg-bg-muted [&_pre]:my-4 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:p-4',
         '[&_code]:bg-bg-muted [&_code]:rounded [&_code]:px-1 [&_code]:text-sm',
-        /* 구분선 */
         '[&_hr]:border-border-base [&_hr]:my-6',
+        '[&_table]:my-4 [&_table]:w-full [&_table]:border-collapse',
+        '[&_th]:border [&_th]:border-gray-300 [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:font-semibold',
+        '[&_td]:border [&_td]:border-gray-300 [&_td]:px-3 [&_td]:py-2',
+        '[&_mark]:rounded-sm',
       ].join(' ')}
-      dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }}
-    />
+    >
+      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+        {safe}
+      </ReactMarkdown>
+    </div>
   )
 }

--- a/src/components/community/PostHeader/PostHeader.tsx
+++ b/src/components/community/PostHeader/PostHeader.tsx
@@ -22,7 +22,9 @@ function formatRelativeTime(isoString: string): string {
   if (sec < 60) return '방금 전'
   if (min < 60) return `${min}분 전`
   if (hour < 24) return `${hour}시간 전`
-  return `${day}일 전`
+  if (day < 7) return `${day}일 전`
+  const d = new Date(isoString)
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`
 }
 
 export function PostHeader({

--- a/src/features/posts/comments/handler.ts
+++ b/src/features/posts/comments/handler.ts
@@ -100,11 +100,15 @@ export const commentsHandlers = [
     const url = new URL(request.url)
     const page = Number(url.searchParams.get('page') ?? 1)
     const pageSize = Number(url.searchParams.get('page_size') ?? 10)
+    const sort = url.searchParams.get('sort') ?? 'latest'
 
-    const total = mockComments.length
+    const sorted =
+      sort === 'oldest' ? [...mockComments].reverse() : mockComments
+
+    const total = sorted.length
     const start = (page - 1) * pageSize
     const end = start + pageSize
-    const results = mockComments.slice(start, end)
+    const results = sorted.slice(start, end)
     const hasNext = end < total
 
     const response: CommentsResponse = {

--- a/src/features/posts/comments/queries.ts
+++ b/src/features/posts/comments/queries.ts
@@ -8,13 +8,19 @@ import type { Comment, CommentsResponse, CommentSubmitRequest } from './types'
 
 const PAGE_SIZE = 10
 
-export function useCommentsInfiniteQuery(postId: number, enabled = true) {
+export type CommentSortOrder = 'latest' | 'oldest'
+
+export function useCommentsInfiniteQuery(
+  postId: number,
+  enabled = true,
+  sortOrder: CommentSortOrder = 'latest'
+) {
   return useInfiniteQuery({
-    queryKey: ['posts', postId, 'comments'],
+    queryKey: ['posts', postId, 'comments', sortOrder],
     queryFn: async ({ pageParam }) => {
       const response = await api.get<CommentsResponse>(
         `/api/v1/posts/${postId}/comments`,
-        { params: { page: pageParam, page_size: PAGE_SIZE } }
+        { params: { page: pageParam, page_size: PAGE_SIZE, sort: sortOrder } }
       )
       return response.data
     },

--- a/src/features/posts/detail/handler.ts
+++ b/src/features/posts/detail/handler.ts
@@ -1,6 +1,6 @@
 import { delay, http, HttpResponse } from 'msw'
 import type { PostDetailResponse } from './types'
-import { likeMockStore } from '../mockStore'
+import { likeMockStore, postMockStore } from '../mockStore'
 
 const dummyPostBase = {
   author: {
@@ -8,13 +8,13 @@ const dummyPostBase = {
     nickname: 'testuser',
     profile_img_url: 'https://example.com/profile.png',
   },
-  category_id: 1,
-  category_name: '자유게시판',
+  category_id: 3,
+  category_name: '자유 게시판',
   title: '테스트 게시글',
   content: '게시글 내용입니다.',
   view_count: 10,
-  created_at: '2026-03-01T12:00:00Z',
-  updated_at: '2026-03-01T12:00:00Z',
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
   comment_count: 5,
 }
 
@@ -22,6 +22,21 @@ export const postDetailHandlers = [
   http.get('/api/v1/posts/:post_id', async ({ params }) => {
     await delay(300)
     const postId = Number(params.post_id)
+
+    // 새로 작성된 게시글은 postMockStore에서 실제 데이터를 반환
+    const stored = postMockStore.get(postId)
+    if (stored) {
+      return HttpResponse.json({
+        ...stored,
+        // 유저가 좋아요 액션을 취한 경우에만 likeMockStore 우선, 아니면 저장된 값(0) 유지
+        like_count: likeMockStore.likeCountMap.has(postId)
+          ? likeMockStore.getLikeCount(postId)
+          : stored.like_count,
+        is_liked: likeMockStore.getIsLiked(postId),
+      })
+    }
+
+    // 기존 mock 게시글은 dummyPostBase 반환
     const response: PostDetailResponse = {
       ...dummyPostBase,
       id: postId,

--- a/src/features/posts/list/handler.ts
+++ b/src/features/posts/list/handler.ts
@@ -1,13 +1,14 @@
 import { http, HttpResponse } from 'msw'
 import type { PostListItem, PostListResponse, PostSortOption } from './types'
+import { postMockStore } from '../mockStore'
 
 const HOUR = 3_600_000
 
 const CATEGORIES = [
-  { id: 1, name: '공지사항' },
-  { id: 2, name: '자유게시판' },
-  { id: 4, name: '구인/협업' },
-  { id: 5, name: '자료공유' },
+  { id: 2, name: '공지사항' },
+  { id: 3, name: '자유 게시판' },
+  { id: 4, name: '일상 공유' },
+  { id: 5, name: '개발 지식 공유' },
 ]
 
 const AUTHORS = [
@@ -27,7 +28,7 @@ const BASE_POSTS: PostListItem[] = [
     content:
       '저는 현재 기초전을 매우 앞서 프로젝트의 업도 섭보 게시하려고 합니다. 데이터 분석 경험 있으신 분들과 함께 사이드 프로젝트 진행하고 싶습니다.',
     thumbnail: null,
-    category: { id: 4, name: '구인/협업' },
+    category: { id: 7, name: '프로젝트 구인' },
     author: AUTHORS[0],
     created_at: new Date(now - 1 * HOUR).toISOString(),
     view_count: 60,
@@ -40,7 +41,7 @@ const BASE_POSTS: PostListItem[] = [
     content:
       'https://www.codeit.kr/costudy/join/684e26b75155062e4621fe77힘께 공부해요. 매일 1시간씩 함께 공부할 러닝 메이트를 찾습니다.',
     thumbnail: null,
-    category: { id: 4, name: '구인/협업' },
+    category: { id: 7, name: '프로젝트 구인' },
     author: AUTHORS[1],
     created_at: new Date(now - 2 * HOUR).toISOString(),
     view_count: 60,
@@ -53,7 +54,7 @@ const BASE_POSTS: PostListItem[] = [
     content:
       'https://www.codeit.kr/costudy/join/684e26b75155062e4621fe77 월요병 극복하는 법 공유해요. 다들 화이팅입니다!',
     thumbnail: 'https://picsum.photos/seed/monday/300/200',
-    category: { id: 2, name: '자유게시판' },
+    category: { id: 3, name: '자유 게시판' },
     author: AUTHORS[2],
     created_at: new Date(now - 3 * HOUR).toISOString(),
     view_count: 60,
@@ -157,7 +158,8 @@ export const postListHandlers = [
     const search = url.searchParams.get('search') ?? ''
     const searchFilter = url.searchParams.get('search_filter') ?? 'title'
 
-    let posts = [...ALL_POSTS]
+    // 새로 작성된 게시글을 맨 앞에 합쳐서 처리
+    let posts = [...postMockStore.getAll(), ...ALL_POSTS]
 
     // 카테고리 필터
     if (categoryId) {

--- a/src/features/posts/mockStore.ts
+++ b/src/features/posts/mockStore.ts
@@ -1,3 +1,6 @@
+import type { PostDetailResponse } from './detail/types'
+import type { PostListItem } from './list/types'
+
 /** MSW 핸들러 간 공유 in-memory 상태 (like_count, is_liked) */
 export const likeMockStore = {
   likeCountMap: new Map<number, number>(),
@@ -6,4 +9,71 @@ export const likeMockStore = {
     likeMockStore.likeCountMap.get(postId) ?? 3,
   getIsLiked: (postId: number): boolean =>
     likeMockStore.isLikedMap.get(postId) ?? false,
+}
+
+export const MOCK_CATEGORIES = [
+  { id: 1, name: '전체 게시판' },
+  { id: 2, name: '공지사항' },
+  { id: 3, name: '자유 게시판' },
+  { id: 4, name: '일상 공유' },
+  { id: 5, name: '개발 지식 공유' },
+  { id: 6, name: '취업 정보 공유' },
+  { id: 7, name: '프로젝트 구인' },
+]
+
+let nextPostId = 1001
+
+/** 새로 작성된 게시글을 핸들러 간 공유하기 위한 in-memory 스토어 */
+export const postMockStore = {
+  posts: new Map<number, PostDetailResponse>(),
+
+  add(data: { title: string; content: string; category_id: number }): number {
+    const id = nextPostId++
+    const category = MOCK_CATEGORIES.find((c) => c.id === data.category_id)
+    const now = new Date().toISOString()
+    postMockStore.posts.set(id, {
+      id,
+      title: data.title,
+      content: data.content,
+      category_id: data.category_id,
+      category_name: category?.name ?? '기타',
+      author: { id: 99, nickname: '테스트유저', profile_img_url: null },
+      view_count: 0,
+      like_count: 0,
+      created_at: now,
+      updated_at: now,
+      comment_count: 0,
+      is_liked: false,
+    })
+    return id
+  },
+
+  get(id: number): PostDetailResponse | undefined {
+    return postMockStore.posts.get(id)
+  },
+
+  /** PostListItem 형식으로 전체 목록 반환 (최신순) */
+  getAll(): PostListItem[] {
+    return Array.from(postMockStore.posts.values())
+      .sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      )
+      .map((p) => ({
+        id: p.id,
+        title: p.title,
+        content: p.content,
+        thumbnail: null,
+        category: { id: p.category_id, name: p.category_name },
+        author: {
+          id: p.author.id,
+          nickname: p.author.nickname,
+          profile_image: p.author.profile_img_url,
+        },
+        created_at: p.created_at,
+        view_count: p.view_count,
+        like_count: p.like_count,
+        comment_count: p.comment_count ?? 0,
+      }))
+  },
 }

--- a/src/features/posts/write/handler.ts
+++ b/src/features/posts/write/handler.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from 'msw'
+import { postMockStore } from '../mockStore'
 
 export const writeHandlers = [
   http.post('/api/v1/posts', async ({ request }) => {
@@ -9,8 +10,13 @@ export const writeHandlers = [
         { status: 400 }
       )
     }
+    const pk = postMockStore.add({
+      title: body.title as string,
+      content: body.content as string,
+      category_id: Number(body.category_id),
+    })
     return HttpResponse.json(
-      { detail: '게시글이 성공적으로 등록되었습니다.', pk: 1 },
+      { detail: '게시글이 성공적으로 등록되었습니다.', pk },
       { status: 201 }
     )
   }),

--- a/src/features/posts/write/queries.ts
+++ b/src/features/posts/write/queries.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '@/api/instance'
 import type {
   CreatePostRequest,
@@ -8,10 +8,14 @@ import type {
 } from './types'
 
 export function useCreatePost() {
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (body: CreatePostRequest) => {
       const { data } = await api.post<CreatePostResponse>('/api/v1/posts', body)
       return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['posts', 'list'] })
     },
   })
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw'
 import { categoriesHandlers } from '@/features/posts/categories'
+import { postListHandlers } from '@/features/posts/list/handler'
 import { writeHandlers } from '@/features/posts/write'
 import { postDetailHandlers } from '@/features/posts/detail'
 import { editHandlers } from '@/features/posts/edit'
@@ -8,7 +9,7 @@ import { postDeleteHandlers } from '@/features/posts/delete'
 import { commentsHandlers } from '@/features/posts/comments'
 import { userSearchHandlers } from '@/features/accounts/user-search'
 
-// categories → detail 순서: /posts/categories가 /posts/:postId보다 먼저 매칭되어야 함
+// categories → list → detail 순서: /posts/categories, /posts/가 /posts/:postId보다 먼저 매칭되어야 함
 export const handlers = [
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' })
@@ -22,6 +23,7 @@ export const handlers = [
     })
   }),
   ...categoriesHandlers,
+  ...postListHandlers,
   ...writeHandlers,
   ...postDetailHandlers,
   ...editHandlers,

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import type { AxiosError } from 'axios'
 import { ROUTES } from '@/constants/routes'
+import { useAuthStore } from '@/stores/authStore'
 import { useCategories } from '@/features/posts/categories'
 import { postDetailQueryOptions } from '@/features/posts/detail'
 import { useUpdatePost } from '@/features/posts/edit'
@@ -24,6 +25,7 @@ interface ToastState {
 export function CommunityEditPage() {
   const navigate = useNavigate()
   const { postId } = useParams<{ postId: string }>()
+  const { isAuthenticated } = useAuthStore()
   const [toast, setToast] = useState<ToastState>({
     visible: false,
     message: '',
@@ -43,6 +45,12 @@ export function CommunityEditPage() {
   } = useQuery(postDetailQueryOptions(Number(postId)))
 
   const { mutate: updatePost, isPending } = useUpdatePost(postId!)
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate(ROUTES.AUTH.LOGIN || '/login', { replace: true })
+    }
+  }, [isAuthenticated, navigate])
 
   useEffect(() => {
     if (isPostError) {

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -6,7 +6,6 @@ import { useNavigate, useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import type { AxiosError } from 'axios'
 import { ROUTES } from '@/constants/routes'
-import { useAuthStore } from '@/stores/authStore'
 import { useCategories } from '@/features/posts/categories'
 import { postDetailQueryOptions } from '@/features/posts/detail'
 import { useUpdatePost } from '@/features/posts/edit'
@@ -30,14 +29,6 @@ export function CommunityEditPage() {
     message: '',
     variant: 'success',
   })
-
-  const { isAuthenticated } = useAuthStore()
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      navigate(ROUTES.AUTH.LOGIN || '/login', { replace: true })
-    }
-  }, [isAuthenticated, navigate])
 
   const {
     data: categories = [],

--- a/src/pages/community/CommunityListPage.tsx
+++ b/src/pages/community/CommunityListPage.tsx
@@ -34,10 +34,12 @@ const CATEGORY_TABS: {
 }[] = [
   { value: 'all', label: '전체', categoryId: undefined },
   { value: 'popular', label: '인기글', categoryId: undefined },
-  { value: 'notice', label: '공지사항', categoryId: 1 },
-  { value: 'free', label: '자유게시판', categoryId: 2 },
-  { value: 'recruit', label: '구인/협업', categoryId: 4 },
-  { value: 'resource', label: '자료공유', categoryId: 5 },
+  { value: 'notice', label: '공지사항', categoryId: 2 },
+  { value: 'free', label: '자유게시판', categoryId: 3 },
+  { value: 'daily', label: '일상 공유', categoryId: 4 },
+  { value: 'dev', label: '개발 지식 공유', categoryId: 5 },
+  { value: 'job', label: '취업 정보 공유', categoryId: 6 },
+  { value: 'recruit', label: '프로젝트 구인', categoryId: 7 },
 ]
 
 function PencilIcon() {

--- a/src/pages/community/CommunityWritePage.tsx
+++ b/src/pages/community/CommunityWritePage.tsx
@@ -1,9 +1,8 @@
 /**
  * @figma 커뮤니티 - 글작성하기  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-5561&m=dev
  */
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
-import { useAuthStore } from '@/stores/authStore'
 import type { AxiosError } from 'axios'
 import { ROUTES } from '@/constants/routes'
 import { useCategories } from '@/features/posts/categories'
@@ -21,18 +20,11 @@ interface ToastState {
 
 export function CommunityWritePage() {
   const navigate = useNavigate()
-  const { isAuthenticated } = useAuthStore()
   const [toast, setToast] = useState<ToastState>({
     visible: false,
     message: '',
     variant: 'success',
   })
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      navigate(ROUTES.AUTH.LOGIN || '/login', { replace: true })
-    }
-  }, [isAuthenticated, navigate])
 
   const {
     data: rawCategories = [],
@@ -61,8 +53,16 @@ export function CommunityWritePage() {
           error_detail?: string | Record<string, string[]>
         }>
         const detail = axiosError.response?.data?.error_detail
-        const message =
-          typeof detail === 'string' ? detail : '요청에 실패했습니다.'
+        let message = '요청에 실패했습니다.'
+        if (typeof detail === 'string') {
+          message = detail
+        } else if (detail && typeof detail === 'object') {
+          const firstValues = Object.values(detail)[0]
+          const firstMsg = Array.isArray(firstValues)
+            ? firstValues[0]
+            : undefined
+          if (firstMsg) message = firstMsg
+        }
         setToast({ visible: true, message, variant: 'error' })
       },
     })

--- a/src/pages/community/CommunityWritePage.tsx
+++ b/src/pages/community/CommunityWritePage.tsx
@@ -1,10 +1,11 @@
 /**
  * @figma 커뮤니티 - 글작성하기  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-5561&m=dev
  */
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router'
 import type { AxiosError } from 'axios'
 import { ROUTES } from '@/constants/routes'
+import { useAuthStore } from '@/stores/authStore'
 import { useCategories } from '@/features/posts/categories'
 import { useCreatePost } from '@/features/posts/write'
 import { Toast } from '@/components/common/Toast'
@@ -20,11 +21,18 @@ interface ToastState {
 
 export function CommunityWritePage() {
   const navigate = useNavigate()
+  const { isAuthenticated } = useAuthStore()
   const [toast, setToast] = useState<ToastState>({
     visible: false,
     message: '',
     variant: 'success',
   })
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate(ROUTES.AUTH.LOGIN || '/login', { replace: true })
+    }
+  }, [isAuthenticated, navigate])
 
   const {
     data: rawCategories = [],

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router'
+import { Routes, Route, Navigate } from 'react-router'
 import { DefaultLayout } from '@/components'
 import {
   CommunityListPage,
@@ -11,6 +11,7 @@ import { ComponentShowcase } from '@/pages/ComponentShowcase'
 export function RouterProvider() {
   return (
     <Routes>
+      <Route path="/" element={<Navigate to="/community" replace />} />
       {/* Header + Footer */}
       <Route element={<DefaultLayout />}>
         <Route path="community">


### PR DESCRIPTION
## 관련 이슈

- closes #64

## 작업 내용

- 마크다운 에디터 취소선 `<del>` HTML 태그 적용 (markdown 파서 충돌 방지)
- 밑줄/정렬/줄간격 토글 기능 (재클릭 시 해제)
- 배경색·글자색 선택기 — 기존 태그 교체 방식으로 개선
- Shift+Enter 한글 IME 글자 중복 버그 수정 (`textarea.value` 사용)
- 글 작성·수정 페이지 인증 가드 복원
- 게시글/댓글 MSW 핸들러 및 목업 데이터 업데이트
- 커뮤니티 작성·수정 페이지 개선

## 변경 사항

- `MarkdownEditor.tsx`: `textarea.value` 기반 IME 호환 Shift+Enter 처리
- `CommunityWritePage.tsx`, `CommunityEditPage.tsx`: 비로그인 시 로그인 페이지 리다이렉트 복원
- `posts/mockStore.ts`, `handler.ts`, `queries.ts`: 목업 데이터 및 핸들러 업데이트

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다