### PR TITLE
fix: 게시글 좋아요 상태 및 캐시 동기화 오류 수정 (#66)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,10 @@
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-markdown": "^10.1.0",
         "react-router": "^7.13.2",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
         "tailwindcss": "^4.2.2",
         "zustand": "^5.0.12"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-markdown": "^10.1.0",
     "react-router": "^7.13.2",
+    "rehype-raw": "^7.0.0",
+    "remark-gfm": "^4.0.1",
     "tailwindcss": "^4.2.2",
     "zustand": "^5.0.12"
   },

--- a/src/features/posts/detail/types.ts
+++ b/src/features/posts/detail/types.ts
@@ -15,8 +15,6 @@ export interface PostDetailResponse {
   like_count: number
   created_at: string
   updated_at: string
-  /** MSW 확장 필드 */
-  is_liked?: boolean
-  /** MSW 확장 필드 */
-  comment_count?: number
+  is_liked: boolean
+  comment_count: number
 }

--- a/src/features/posts/like/queries.ts
+++ b/src/features/posts/like/queries.ts
@@ -5,6 +5,7 @@ import type { PostDetailResponse } from '../detail/types'
 
 export const useTogglePostLike = (postId: number) => {
   const queryClient = useQueryClient()
+  const queryKey = ['posts', 'detail', postId]
 
   return useMutation({
     mutationFn: async (isCurrentlyLiked: boolean) => {
@@ -13,18 +14,28 @@ export const useTogglePostLike = (postId: number) => {
         : await api.post<PostLikeResponse>(`/api/v1/posts/${postId}/like`)
       return data
     },
-    onSuccess: (data) => {
-      queryClient.setQueryData<PostDetailResponse>(
-        ['posts', 'detail', postId],
-        (prev) => {
-          if (!prev) return prev
-          return {
-            ...prev,
-            is_liked: data.is_liked,
-            like_count: data.like_count,
-          }
+    onMutate: async (isCurrentlyLiked: boolean) => {
+      await queryClient.cancelQueries({ queryKey })
+      const previous = queryClient.getQueryData<PostDetailResponse>(queryKey)
+      queryClient.setQueryData<PostDetailResponse>(queryKey, (prev) => {
+        if (!prev) return prev
+        return {
+          ...prev,
+          is_liked: !isCurrentlyLiked,
+          like_count: isCurrentlyLiked
+            ? prev.like_count - 1
+            : prev.like_count + 1,
         }
-      )
+      })
+      return { previous }
+    },
+    onError: (_err, _isCurrentlyLiked, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey })
     },
   })
 }

--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -66,8 +66,6 @@ function CommunityDetailContent({ postId }: { postId: number }) {
 
   const isAuthor = isAuthenticated && user?.id === post.author.id
 
-  const [isLiked, setIsLiked] = useState(post.is_liked ?? false)
-  const [likeCount, setLikeCount] = useState(post.like_count)
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [toast, setToast] = useState<{
     message: string
@@ -97,22 +95,8 @@ function CommunityDetailContent({ postId }: { postId: number }) {
     }
     if (isLikePending) return
 
-    // 낙관적 업데이트: API 응답 전 즉시 UI 반영
-    const prevLiked = isLiked
-    const prevCount = likeCount
-    setIsLiked(!isLiked)
-    setLikeCount(isLiked ? likeCount - 1 : likeCount + 1)
-
-    toggleLike(isLiked, {
-      onSuccess: (data) => {
-        // 서버 응답으로 최종 동기화
-        setIsLiked(data.is_liked)
-        setLikeCount(data.like_count)
-      },
+    toggleLike(post.is_liked, {
       onError: () => {
-        // 실패 시 이전 상태로 롤백
-        setIsLiked(prevLiked)
-        setLikeCount(prevCount)
         showToast('좋아요 처리에 실패했습니다.', 'error')
       },
     })
@@ -159,7 +143,7 @@ function CommunityDetailContent({ postId }: { postId: number }) {
           }}
           createdAt={post.created_at}
           viewCount={post.view_count}
-          likeCount={likeCount}
+          likeCount={post.like_count}
         />
 
         {/* 수정/삭제 버튼 — 작성자 전용 */}
@@ -180,8 +164,8 @@ function CommunityDetailContent({ postId }: { postId: number }) {
 
         {/* 좋아요 */}
         <PostActions
-          likeCount={likeCount}
-          isLiked={isLiked}
+          likeCount={post.like_count}
+          isLiked={post.is_liked}
           isLoggedIn={isAuthenticated}
           isLikePending={isLikePending}
           onLike={handleLike}


### PR DESCRIPTION
## 관련 이슈

- closes #66

## 작업 내용

- `detail/types.ts`: `is_liked`, `comment_count`를 optional에서 required로 변경
- `like/queries.ts`: `onMutate`/`onError`/`onSettled` 패턴 적용
- `CommunityDetailPage.tsx`: 좋아요 관련 이중 `useState` 제거, Query Cache 직접 사용

## 변경 사항

- **detail/types.ts**: `is_liked?: boolean` → `is_liked: boolean`, `comment_count?: number` → `comment_count: number`로 변경해 초기 상태 동기화 문제 해결
- **like/queries.ts**:
  - `cancelQueries`로 진행 중인 refetch를 취소해 race condition 방지
  - `onMutate`에서 낙관적 업데이트 (Query Cache 직접 수정)
  - `onError`에서 이전 캐시 값으로 rollback
  - `onSettled`에서 `invalidateQueries`로 서버 상태 최종 동기화
- **CommunityDetailPage.tsx**: `isLiked`/`likeCount` useState 제거, `post.is_liked`·`post.like_count` 직접 참조. 낙관적 업데이트는 Query Cache에서 처리

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다