### PR TITLE
fix: 게시글 상세 조회 및 삭제 안정성 개선 (#68)

### DIFF
--- a/src/features/posts/delete/handler.ts
+++ b/src/features/posts/delete/handler.ts
@@ -1,9 +1,21 @@
 import { delay, http, HttpResponse } from 'msw'
 import type { PostDeleteResponse } from './types'
+import { postMockStore } from '../mockStore'
 
 export const postDeleteHandlers = [
-  http.delete('/api/v1/posts/:post_id', async () => {
+  http.delete('/api/v1/posts/:post_id', async ({ params }) => {
     await delay(300)
+    const postId = Number(params.post_id)
+
+    if (postId === 999) {
+      return HttpResponse.json(
+        { error_detail: '해당 게시글을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    postMockStore.posts.delete(postId)
+
     const body: PostDeleteResponse = {
       detail: '게시글이 삭제되었습니다.',
     }

--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -3,7 +3,7 @@
  * @figma 커뮤니티 상세 페이지 (회원)        https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10585&m=dev
  * @figma 커뮤니티 상세 페이지 (회원-작성자) https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-10696&m=dev
  */
-import { Component, Suspense, useState } from 'react'
+import { Component, Suspense, useState, useRef } from 'react'
 import type { ErrorInfo, ReactNode } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { ConfirmModal } from '@/components/common/Modal/ConfirmModal'
@@ -66,6 +66,7 @@ function CommunityDetailContent({ postId }: { postId: number }) {
 
   const isAuthor = isAuthenticated && user?.id === post.author.id
 
+  const pendingNavigate = useRef<string | null>(null)
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [toast, setToast] = useState<{
     message: string
@@ -107,8 +108,8 @@ function CommunityDetailContent({ postId }: { postId: number }) {
     deletePost(postId, {
       onSuccess: () => {
         setIsDeleteModalOpen(false)
+        pendingNavigate.current = '/community'
         showToast('게시글이 삭제되었습니다.', 'success')
-        setTimeout(() => navigate('/community'), 1500)
       },
       onError: () => {
         showToast('게시글 삭제에 실패했습니다.', 'error')
@@ -199,7 +200,13 @@ function CommunityDetailContent({ postId }: { postId: number }) {
         message={toast.message}
         variant={toast.variant}
         visible={toast.visible}
-        onClose={() => setToast((prev) => ({ ...prev, visible: false }))}
+        onClose={() => {
+          setToast((prev) => ({ ...prev, visible: false }))
+          if (pendingNavigate.current) {
+            navigate(pendingNavigate.current)
+            pendingNavigate.current = null
+          }
+        }}
       />
     </main>
   )
@@ -209,7 +216,7 @@ export function CommunityDetailPage() {
   const { postId } = useParams<{ postId: string }>()
   const postIdNum = Number(postId)
 
-  if (isNaN(postIdNum)) {
+  if (isNaN(postIdNum) || postIdNum <= 0) {
     return (
       <main className="mx-auto max-w-4xl px-4 py-10">
         <p className="text-text-muted">잘못된 게시글 ID입니다.</p>


### PR DESCRIPTION
## 관련 이슈

- closes #68

## 작업 내용

- `CommunityDetailPage.tsx`: `postId <= 0` 유효성 검증 추가
- `CommunityDetailPage.tsx`: `setTimeout` 제거, Toast `onClose` 기반 navigate 처리
- `delete/handler.ts`: `params.post_id` 사용, `postId` 기반 404 시나리오 처리, `postMockStore` 연동

## 변경 사항

- **CommunityDetailPage.tsx**:
  - `isNaN(postIdNum)` → `isNaN(postIdNum) || postIdNum <= 0`으로 강화
  - `setTimeout(() => navigate('/community'), 1500)` 제거 → `useRef(pendingNavigate)`에 경로 저장 후 Toast `onClose`에서 navigate 실행 (cleanup 누락 문제 해결)
- **delete/handler.ts**:
  - `async ()` → `async ({ params })`로 `post_id` 추출
  - `postId === 999` 시 404 반환
  - `postMockStore.posts.delete(postId)`로 실제 mock 데이터 삭제 처리

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다