### PR TITLE
feat: 게시글 좋아요 생성 및 취소 API 연동 (#73)

### DIFF
--- a/src/features/posts/like/handler.ts
+++ b/src/features/posts/like/handler.ts
@@ -16,7 +16,7 @@ export const postLikeHandlers = [
     }
     return HttpResponse.json(body)
   }),
-  http.delete('/api/v1/posts/:post_id/like', ({ params }) => {
+  http.delete('/api/v1/posts/:post_id/like/cancel', ({ params }) => {
     const postId = Number(params.post_id)
     const newCount = Math.max(0, likeMockStore.getLikeCount(postId) - 1)
     likeMockStore.likeCountMap.set(postId, newCount)

--- a/src/features/posts/like/queries.ts
+++ b/src/features/posts/like/queries.ts
@@ -10,7 +10,9 @@ export const useTogglePostLike = (postId: number) => {
   return useMutation({
     mutationFn: async (isCurrentlyLiked: boolean) => {
       const { data } = isCurrentlyLiked
-        ? await api.delete<PostLikeResponse>(`/api/v1/posts/${postId}/like`)
+        ? await api.delete<PostLikeResponse>(
+            `/api/v1/posts/${postId}/like/cancel`
+          )
         : await api.post<PostLikeResponse>(`/api/v1/posts/${postId}/like`)
       return data
     },

--- a/src/pages/community/CommunityListPage.tsx
+++ b/src/pages/community/CommunityListPage.tsx
@@ -268,34 +268,32 @@ export function CommunityListPage() {
 
       {/* 글 목록 */}
       <div className="flex min-h-96 w-full flex-col gap-10">
-        <div className="min-h-96 w-full">
-          {isLoading && (
-            <p className="text-text-muted py-16 text-center text-sm">
-              불러오는 중...
-            </p>
-          )}
-          {isError && (
-            <p className="text-error py-16 text-center text-sm">
-              게시글을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
-            </p>
-          )}
-          {!isLoading && !isError && (data?.results?.length ?? 0) === 0 && (
-            <p className="text-text-muted py-16 text-center text-sm">
-              게시글이 없습니다.
-            </p>
-          )}
-          {data?.results?.map((post) => (
-            <PostCard
-              key={post.id}
-              post={post}
-              onClick={() =>
-                navigate(
-                  ROUTES.COMMUNITY.DETAIL.replace(':postId', String(post.id))
-                )
-              }
-            />
-          ))}
-        </div>
+        {isLoading && (
+          <p className="text-text-muted py-16 text-center text-sm">
+            불러오는 중...
+          </p>
+        )}
+        {isError && (
+          <p className="text-error py-16 text-center text-sm">
+            게시글을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+          </p>
+        )}
+        {!isLoading && !isError && (data?.results?.length ?? 0) === 0 && (
+          <p className="text-text-muted py-16 text-center text-sm">
+            게시글이 없습니다.
+          </p>
+        )}
+        {data?.results?.map((post) => (
+          <PostCard
+            key={post.id}
+            post={post}
+            onClick={() =>
+              navigate(
+                ROUTES.COMMUNITY.DETAIL.replace(':postId', String(post.id))
+              )
+            }
+          />
+        ))}
       </div>
 
       {/* 페이지네이션 */}

--- a/src/pages/community/CommunityListPage.tsx
+++ b/src/pages/community/CommunityListPage.tsx
@@ -268,32 +268,34 @@ export function CommunityListPage() {
 
       {/* 글 목록 */}
       <div className="flex min-h-96 w-full flex-col gap-10">
-        {isLoading && (
-          <p className="text-text-muted py-16 text-center text-sm">
-            불러오는 중...
-          </p>
-        )}
-        {isError && (
-          <p className="text-error py-16 text-center text-sm">
-            게시글을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
-          </p>
-        )}
-        {!isLoading && !isError && (data?.results?.length ?? 0) === 0 && (
-          <p className="text-text-muted py-16 text-center text-sm">
-            게시글이 없습니다.
-          </p>
-        )}
-        {data?.results?.map((post) => (
-          <PostCard
-            key={post.id}
-            post={post}
-            onClick={() =>
-              navigate(
-                ROUTES.COMMUNITY.DETAIL.replace(':postId', String(post.id))
-              )
-            }
-          />
-        ))}
+        <div className="min-h-96 w-full">
+          {isLoading && (
+            <p className="text-text-muted py-16 text-center text-sm">
+              불러오는 중...
+            </p>
+          )}
+          {isError && (
+            <p className="text-error py-16 text-center text-sm">
+              게시글을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+            </p>
+          )}
+          {!isLoading && !isError && (data?.results?.length ?? 0) === 0 && (
+            <p className="text-text-muted py-16 text-center text-sm">
+              게시글이 없습니다.
+            </p>
+          )}
+          {data?.results?.map((post) => (
+            <PostCard
+              key={post.id}
+              post={post}
+              onClick={() =>
+                navigate(
+                  ROUTES.COMMUNITY.DETAIL.replace(':postId', String(post.id))
+                )
+              }
+            />
+          ))}
+        </div>
       </div>
 
       {/* 페이지네이션 */}


### PR DESCRIPTION
## 관련 이슈

- closes #73

## 작업 내용

- `like/queries.ts`: 좋아요 취소 엔드포인트 변경 (`DELETE /like` → `DELETE /like/cancel`)
- `like/handler.ts`: MSW 핸들러 경로 동일하게 변경

## 변경 사항

- **like/queries.ts**: `DELETE /api/v1/posts/${postId}/like` → `DELETE /api/v1/posts/${postId}/like/cancel`
- **like/handler.ts**: `http.delete('/api/v1/posts/:post_id/like', ...)` → `http.delete('/api/v1/posts/:post_id/like/cancel', ...)`
- **handlers.ts**: 중복 import 제거 (빌드 에러 수정)
- **CommunityListPage.tsx**: 빌드 에러 수정

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다