### PR TITLE
feat: 마크다운 에디터 서식 중복 방어 및 Enter 키 동작 개선

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -128,7 +128,7 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
     event,
     client,
     requestId,
-    requestInterceptedAt,
+    requestInterceptedAt
   )
 
   // Send back the response clone for the "response:*" life-cycle events.
@@ -159,7 +159,7 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
           },
         },
       },
-      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+      responseClone.body ? [serializedRequest.body, responseClone.body] : []
     )
   }
 
@@ -225,7 +225,7 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
     if (acceptHeader) {
       const values = acceptHeader.split(',').map((value) => value.trim())
       const filteredValues = values.filter(
-        (value) => value !== 'msw/passthrough',
+        (value) => value !== 'msw/passthrough'
       )
 
       if (filteredValues.length > 0) {
@@ -263,7 +263,7 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
         ...serializedRequest,
       },
     },
-    [serializedRequest.body],
+    [serializedRequest.body]
   )
 
   switch (clientMessage.type) {

--- a/src/components/community/MarkdownEditor/MarkdownEditor.css
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.css
@@ -232,3 +232,28 @@
   transform: scale(1.2);
   border-color: #64748b;
 }
+
+/* ── Notion 스타일 리스트 ── */
+.post-editor-wrap .wmde-markdown ul {
+  list-style-type: disc;
+  padding-left: 1.5em;
+  margin: 0.25em 0;
+}
+
+.post-editor-wrap .wmde-markdown ul ul {
+  list-style-type: circle;
+}
+
+.post-editor-wrap .wmde-markdown ul ul ul {
+  list-style-type: square;
+}
+
+.post-editor-wrap .wmde-markdown ol {
+  list-style-type: decimal;
+  padding-left: 1.5em;
+  margin: 0.25em 0;
+}
+
+.post-editor-wrap .wmde-markdown li {
+  margin: 0.1em 0;
+}

--- a/src/components/community/MarkdownEditor/MarkdownEditor.css
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.css
@@ -1,4 +1,4 @@
-/* ── MDEditor 외부 border/shadow 제거 ── */
+/* ── MDEditor CSS 변수 오버라이드: 외부 border/shadow 제거 ── */
 .post-editor-wrap .w-md-editor {
   --md-editor-box-shadow-color: transparent;
   box-shadow: none !important;
@@ -34,7 +34,7 @@
   background-color: #fafafa !important;
 }
 
-/* ── 툴바 ── */
+/* ── 툴바 전체 컨테이너 ── */
 .post-editor-wrap .w-md-editor-toolbar {
   display: flex !important;
   flex-direction: column !important;
@@ -47,6 +47,7 @@
   overflow: visible !important;
 }
 
+/* Row 1 (commands UL), Row 2 (extraCommands UL) 각각 한 줄 전체 사용 */
 .post-editor-wrap .w-md-editor-toolbar > ul {
   display: flex !important;
   flex-direction: row !important;
@@ -61,6 +62,7 @@
   box-sizing: border-box !important;
 }
 
+/* 툴바 divider */
 .post-editor-wrap .w-md-editor-toolbar-divider {
   background-color: #cdcdcd !important;
   height: 16px !important;
@@ -68,12 +70,14 @@
   margin: 0 4px !important;
 }
 
+/* 툴바 버튼 */
 .post-editor-wrap .w-md-editor-toolbar li {
   display: inline-flex !important;
   align-items: center !important;
   position: relative !important;
 }
 
+/* ── 드롭다운 자식 패널: 버튼 아래로 표시 ── */
 .post-editor-wrap .w-md-editor-toolbar-child {
   top: 100% !important;
   left: 0 !important;
@@ -96,4 +100,160 @@
 .post-editor-wrap .w-md-editor-toolbar li > button[data-inactive='true'] {
   pointer-events: none !important;
   opacity: 0.3 !important;
+}
+
+/* ── Tab 들여쓰기로 생성된 인덴티드 코드블록 배경 제거 ── */
+/* pre:not([class]) = 언어 미지정 코드블록 (4칸 들여쓰기 또는 언어 없는 펜싱) */
+.post-editor-wrap .wmde-markdown pre:not([class]) {
+  background-color: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+/* ── 목록 스타일 복원 ── */
+.post-editor-wrap .wmde-markdown ul {
+  list-style-type: disc !important;
+  padding-left: 2em !important;
+  margin: 0.5em 0 !important;
+}
+
+.post-editor-wrap .wmde-markdown ol {
+  list-style-type: decimal !important;
+  padding-left: 2em !important;
+  margin: 0.5em 0 !important;
+}
+
+.post-editor-wrap .wmde-markdown li {
+  display: list-item !important;
+}
+
+.post-editor-wrap .wmde-markdown ul ul {
+  list-style-type: circle !important;
+}
+
+.post-editor-wrap .wmde-markdown ul ul ul {
+  list-style-type: square !important;
+}
+
+.post-editor-wrap .wmde-markdown ol ol {
+  list-style-type: lower-alpha !important;
+}
+
+.post-editor-wrap .wmde-markdown ol ol ol {
+  list-style-type: lower-roman !important;
+}
+
+/* ── 헤딩 스타일 복원 ── */
+.post-editor-wrap .wmde-markdown h1 {
+  font-size: 2em !important;
+  font-weight: 700 !important;
+  margin: 0.67em 0 !important;
+  border-bottom: none !important;
+}
+.post-editor-wrap .wmde-markdown h2 {
+  font-size: 1.5em !important;
+  font-weight: 700 !important;
+  margin: 0.75em 0 !important;
+  border-bottom: none !important;
+}
+.post-editor-wrap .wmde-markdown h3 {
+  font-size: 1.25em !important;
+  font-weight: 600 !important;
+  margin: 0.83em 0 !important;
+}
+.post-editor-wrap .wmde-markdown h4 {
+  font-size: 1em !important;
+  font-weight: 600 !important;
+  margin: 1em 0 !important;
+}
+.post-editor-wrap .wmde-markdown h5 {
+  font-size: 0.875em !important;
+  font-weight: 600 !important;
+  margin: 1.17em 0 !important;
+}
+.post-editor-wrap .wmde-markdown h6 {
+  font-size: 0.85em !important;
+  font-weight: 600 !important;
+  margin: 1.33em 0 !important;
+  color: #6b7280 !important;
+}
+
+/* ── 드롭다운 팝업 ── */
+.toolbar-popup {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 4px;
+  width: max-content;
+  z-index: 200;
+}
+
+.toolbar-popup button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 5px 10px;
+  font-size: 13px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 4px;
+  white-space: nowrap;
+  color: #374151;
+}
+
+.toolbar-popup button:hover {
+  background: #f1f5f9;
+}
+
+/* ── 색상 팔레트 ── */
+.color-palette {
+  display: grid;
+  grid-template-columns: repeat(5, 22px);
+  gap: 3px;
+  padding: 7px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.color-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 3px;
+  cursor: pointer;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  transition: transform 0.1s;
+}
+
+.color-swatch:hover {
+  transform: scale(1.2);
+  border-color: #64748b;
+}
+
+/* ── Notion 스타일 리스트 ── */
+.post-editor-wrap .wmde-markdown ul {
+  list-style-type: disc;
+  padding-left: 1.5em;
+  margin: 0.25em 0;
+}
+
+.post-editor-wrap .wmde-markdown ul ul {
+  list-style-type: circle;
+}
+
+.post-editor-wrap .wmde-markdown ul ul ul {
+  list-style-type: square;
+}
+
+.post-editor-wrap .wmde-markdown ol {
+  list-style-type: decimal;
+  padding-left: 1.5em;
+  margin: 0.25em 0;
+}
+
+.post-editor-wrap .wmde-markdown li {
+  margin: 0.1em 0;
 }

--- a/src/components/community/MarkdownEditor/MarkdownEditor.css
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.css
@@ -1,4 +1,4 @@
-/* ── MDEditor CSS 변수 오버라이드: 외부 border/shadow 제거 ── */
+/* ── MDEditor 외부 border/shadow 제거 ── */
 .post-editor-wrap .w-md-editor {
   --md-editor-box-shadow-color: transparent;
   box-shadow: none !important;
@@ -34,7 +34,7 @@
   background-color: #fafafa !important;
 }
 
-/* ── 툴바 전체 컨테이너 ── */
+/* ── 툴바 ── */
 .post-editor-wrap .w-md-editor-toolbar {
   display: flex !important;
   flex-direction: column !important;
@@ -47,7 +47,6 @@
   overflow: visible !important;
 }
 
-/* Row 1 (commands UL), Row 2 (extraCommands UL) 각각 한 줄 전체 사용 */
 .post-editor-wrap .w-md-editor-toolbar > ul {
   display: flex !important;
   flex-direction: row !important;
@@ -62,7 +61,6 @@
   box-sizing: border-box !important;
 }
 
-/* 툴바 divider */
 .post-editor-wrap .w-md-editor-toolbar-divider {
   background-color: #cdcdcd !important;
   height: 16px !important;
@@ -70,14 +68,12 @@
   margin: 0 4px !important;
 }
 
-/* 툴바 버튼 */
 .post-editor-wrap .w-md-editor-toolbar li {
   display: inline-flex !important;
   align-items: center !important;
   position: relative !important;
 }
 
-/* ── 드롭다운 자식 패널: 버튼 아래로 표시 ── */
 .post-editor-wrap .w-md-editor-toolbar-child {
   top: 100% !important;
   left: 0 !important;
@@ -100,160 +96,4 @@
 .post-editor-wrap .w-md-editor-toolbar li > button[data-inactive='true'] {
   pointer-events: none !important;
   opacity: 0.3 !important;
-}
-
-/* ── Tab 들여쓰기로 생성된 인덴티드 코드블록 배경 제거 ── */
-/* pre:not([class]) = 언어 미지정 코드블록 (4칸 들여쓰기 또는 언어 없는 펜싱) */
-.post-editor-wrap .wmde-markdown pre:not([class]) {
-  background-color: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
-}
-
-/* ── 목록 스타일 복원 ── */
-.post-editor-wrap .wmde-markdown ul {
-  list-style-type: disc !important;
-  padding-left: 2em !important;
-  margin: 0.5em 0 !important;
-}
-
-.post-editor-wrap .wmde-markdown ol {
-  list-style-type: decimal !important;
-  padding-left: 2em !important;
-  margin: 0.5em 0 !important;
-}
-
-.post-editor-wrap .wmde-markdown li {
-  display: list-item !important;
-}
-
-.post-editor-wrap .wmde-markdown ul ul {
-  list-style-type: circle !important;
-}
-
-.post-editor-wrap .wmde-markdown ul ul ul {
-  list-style-type: square !important;
-}
-
-.post-editor-wrap .wmde-markdown ol ol {
-  list-style-type: lower-alpha !important;
-}
-
-.post-editor-wrap .wmde-markdown ol ol ol {
-  list-style-type: lower-roman !important;
-}
-
-/* ── 헤딩 스타일 복원 ── */
-.post-editor-wrap .wmde-markdown h1 {
-  font-size: 2em !important;
-  font-weight: 700 !important;
-  margin: 0.67em 0 !important;
-  border-bottom: none !important;
-}
-.post-editor-wrap .wmde-markdown h2 {
-  font-size: 1.5em !important;
-  font-weight: 700 !important;
-  margin: 0.75em 0 !important;
-  border-bottom: none !important;
-}
-.post-editor-wrap .wmde-markdown h3 {
-  font-size: 1.25em !important;
-  font-weight: 600 !important;
-  margin: 0.83em 0 !important;
-}
-.post-editor-wrap .wmde-markdown h4 {
-  font-size: 1em !important;
-  font-weight: 600 !important;
-  margin: 1em 0 !important;
-}
-.post-editor-wrap .wmde-markdown h5 {
-  font-size: 0.875em !important;
-  font-weight: 600 !important;
-  margin: 1.17em 0 !important;
-}
-.post-editor-wrap .wmde-markdown h6 {
-  font-size: 0.85em !important;
-  font-weight: 600 !important;
-  margin: 1.33em 0 !important;
-  color: #6b7280 !important;
-}
-
-/* ── 드롭다운 팝업 ── */
-.toolbar-popup {
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  padding: 4px;
-  width: max-content;
-  z-index: 200;
-}
-
-.toolbar-popup button {
-  display: block;
-  width: 100%;
-  text-align: left;
-  padding: 5px 10px;
-  font-size: 13px;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  border-radius: 4px;
-  white-space: nowrap;
-  color: #374151;
-}
-
-.toolbar-popup button:hover {
-  background: #f1f5f9;
-}
-
-/* ── 색상 팔레트 ── */
-.color-palette {
-  display: grid;
-  grid-template-columns: repeat(5, 22px);
-  gap: 3px;
-  padding: 7px;
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
-
-.color-swatch {
-  width: 22px;
-  height: 22px;
-  border-radius: 3px;
-  cursor: pointer;
-  border: 1px solid rgba(0, 0, 0, 0.12);
-  transition: transform 0.1s;
-}
-
-.color-swatch:hover {
-  transform: scale(1.2);
-  border-color: #64748b;
-}
-
-/* ── Notion 스타일 리스트 ── */
-.post-editor-wrap .wmde-markdown ul {
-  list-style-type: disc;
-  padding-left: 1.5em;
-  margin: 0.25em 0;
-}
-
-.post-editor-wrap .wmde-markdown ul ul {
-  list-style-type: circle;
-}
-
-.post-editor-wrap .wmde-markdown ul ul ul {
-  list-style-type: square;
-}
-
-.post-editor-wrap .wmde-markdown ol {
-  list-style-type: decimal;
-  padding-left: 1.5em;
-  margin: 0.25em 0;
-}
-
-.post-editor-wrap .wmde-markdown li {
-  margin: 0.1em 0;
 }

--- a/src/components/community/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.tsx
@@ -627,6 +627,46 @@ const clearFormatCmd: ICommand = {
   },
 }
 
+const boldCommand: ICommand = {
+  ...mdCommands.bold,
+  execute: (state, api) => {
+    const sel = state.selectedText
+    if (sel.startsWith('***') && sel.endsWith('***') && sel.length >= 6) {
+      api.replaceSelection('*' + sel.slice(3, -3) + '*')
+    } else if (
+      sel.startsWith('**') &&
+      !sel.startsWith('***') &&
+      sel.endsWith('**') &&
+      !sel.endsWith('***') &&
+      sel.length >= 4
+    ) {
+      api.replaceSelection(sel.slice(2, -2))
+    } else {
+      api.replaceSelection(`**${sel}**`)
+    }
+  },
+}
+
+const italicCommand: ICommand = {
+  ...mdCommands.italic,
+  execute: (state, api) => {
+    const sel = state.selectedText
+    if (sel.startsWith('***') && sel.endsWith('***') && sel.length >= 6) {
+      api.replaceSelection('**' + sel.slice(3, -3) + '**')
+    } else if (
+      sel.startsWith('*') &&
+      !sel.startsWith('**') &&
+      sel.endsWith('*') &&
+      !sel.endsWith('**') &&
+      sel.length >= 2
+    ) {
+      api.replaceSelection(sel.slice(1, -1))
+    } else {
+      api.replaceSelection(`*${sel}*`)
+    }
+  },
+}
+
 const UNDO_LIMIT = 50
 
 export function MarkdownEditor({
@@ -765,8 +805,8 @@ export function MarkdownEditor({
       fontFamilyCommand,
       fontSizeCommand,
       mdCommands.divider,
-      mdCommands.bold,
-      mdCommands.italic,
+      boldCommand,
+      italicCommand,
       underlineCommand,
       strikethroughCommand,
       bgColorCommand,
@@ -819,6 +859,114 @@ export function MarkdownEditor({
                   textarea.selectionStart = start + insert.length
                   textarea.selectionEnd = start + insert.length
                 })
+              }
+              if (!e.shiftKey && e.key === 'Enter') {
+                const textarea = e.currentTarget
+                const start = textarea.selectionStart
+                const end = textarea.selectionEnd
+                const text = textarea.value
+                const lineStart = text.lastIndexOf('\n', start - 1) + 1
+                const lineNlPos = text.indexOf('\n', lineStart)
+                const lineEnd = lineNlPos === -1 ? text.length : lineNlPos
+                const currentLine = text.substring(lineStart, lineEnd)
+                if (/^>/.test(currentLine)) {
+                  e.preventDefault()
+                  if (!/^>\s*$/.test(currentLine)) {
+                    const insert = '\n> '
+                    const next =
+                      text.substring(0, start) + insert + text.substring(end)
+                    handleChange(next)
+                    requestAnimationFrame(() => {
+                      textarea.selectionStart = start + insert.length
+                      textarea.selectionEnd = start + insert.length
+                    })
+                  } else {
+                    const prevLineEnd = lineStart - 1
+                    const isPrevEmptyBlockquote =
+                      prevLineEnd >= 0 &&
+                      /^>\s*$/.test(
+                        text.substring(
+                          text.lastIndexOf('\n', prevLineEnd - 1) + 1,
+                          prevLineEnd
+                        )
+                      )
+                    if (isPrevEmptyBlockquote) {
+                      const next =
+                        text.substring(0, lineStart) +
+                        text.substring(lineStart + currentLine.length)
+                      handleChange(next)
+                      requestAnimationFrame(() => {
+                        textarea.selectionStart = lineStart
+                        textarea.selectionEnd = lineStart
+                      })
+                    } else {
+                      const insert = '\n> '
+                      const next =
+                        text.substring(0, start) + insert + text.substring(end)
+                      handleChange(next)
+                      requestAnimationFrame(() => {
+                        textarea.selectionStart = start + insert.length
+                        textarea.selectionEnd = start + insert.length
+                      })
+                    }
+                  }
+                } else if (/^\s+[-*]\s*/.test(currentLine)) {
+                  e.preventDefault()
+                  const listMatch = currentLine.match(/^(\s+)([-*])\s*/)
+                  if (listMatch) {
+                    const indent = listMatch[1]
+                    const marker = listMatch[2]
+                    const prefix = `${indent}${marker} `
+                    const isEmptyItem = /^\s+[-*]\s*$/.test(currentLine)
+                    if (!isEmptyItem) {
+                      const insert = `\n${prefix}`
+                      const next =
+                        text.substring(0, start) + insert + text.substring(end)
+                      handleChange(next)
+                      requestAnimationFrame(() => {
+                        textarea.selectionStart = start + insert.length
+                        textarea.selectionEnd = start + insert.length
+                      })
+                    } else {
+                      const prevLineEnd = lineStart - 1
+                      const isPrevEmptyItem =
+                        prevLineEnd >= 0 &&
+                        /^\s+[-*]\s*$/.test(
+                          text.substring(
+                            text.lastIndexOf('\n', prevLineEnd - 1) + 1,
+                            prevLineEnd
+                          )
+                        )
+                      if (isPrevEmptyItem) {
+                        const newIndent = indent.slice(2)
+                        const replacement = newIndent
+                          ? `${newIndent}${marker} `
+                          : `${marker} `
+                        const next =
+                          text.substring(0, lineStart) +
+                          replacement +
+                          text.substring(lineStart + currentLine.length)
+                        handleChange(next)
+                        requestAnimationFrame(() => {
+                          textarea.selectionStart =
+                            lineStart + replacement.length
+                          textarea.selectionEnd = lineStart + replacement.length
+                        })
+                      } else {
+                        const insert = `\n${prefix}`
+                        const next =
+                          text.substring(0, start) +
+                          insert +
+                          text.substring(end)
+                        handleChange(next)
+                        requestAnimationFrame(() => {
+                          textarea.selectionStart = start + insert.length
+                          textarea.selectionEnd = start + insert.length
+                        })
+                      }
+                    }
+                  }
+                }
               }
               if (e.key === 'Tab') {
                 e.preventDefault()

--- a/src/components/community/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.tsx
@@ -820,6 +820,21 @@ export function MarkdownEditor({
                   textarea.selectionEnd = start + insert.length
                 })
               }
+              if (e.key === 'Tab') {
+                e.preventDefault()
+                const textarea = e.currentTarget
+                const start = textarea.selectionStart
+                const end = textarea.selectionEnd
+                const insert = '  '
+                const current = textarea.value
+                const next =
+                  current.substring(0, start) + insert + current.substring(end)
+                handleChange(next)
+                requestAnimationFrame(() => {
+                  textarea.selectionStart = start + insert.length
+                  textarea.selectionEnd = start + insert.length
+                })
+              }
             },
           }}
         />

--- a/src/components/community/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.tsx
@@ -3,6 +3,22 @@ import MDEditor, {
   commands as mdCommands,
   type ICommand,
 } from '@uiw/react-md-editor'
+import {
+  Undo2,
+  Redo2,
+  Underline,
+  Strikethrough,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  AlignJustify,
+  List,
+  ChevronDown,
+  ArrowUpDown,
+  RemoveFormatting,
+  IndentIncrease,
+  IndentDecrease,
+} from 'lucide-react'
 import './MarkdownEditor.css'
 
 export interface MarkdownEditorProps {
@@ -18,6 +34,598 @@ const ACCEPTED_IMAGE_TYPES = [
   'image/gif',
   'image/webp',
 ]
+
+const FONT_FAMILIES = [
+  { label: '기본서체', value: 'inherit' },
+  { label: 'Arial', value: 'Arial, sans-serif' },
+  { label: '돋움', value: 'Dotum, sans-serif' },
+  { label: '맑은 고딕', value: "'Malgun Gothic', sans-serif" },
+  { label: 'Georgia', value: 'Georgia, serif' },
+  { label: 'Courier New', value: "'Courier New', monospace" },
+]
+
+const FONT_SIZES = [10, 12, 14, 16, 18, 20, 24, 28, 32]
+
+const PALETTE_COLORS = [
+  '#000000',
+  '#434343',
+  '#666666',
+  '#999999',
+  '#b7b7b7',
+  '#ff0000',
+  '#ff7700',
+  '#ffff00',
+  '#00ff00',
+  '#0000ff',
+  '#9900ff',
+  '#ff00ff',
+  '#00ffff',
+  '#ff6d6d',
+  '#ffd966',
+  '#93c47d',
+  '#76a5af',
+  '#4a86e8',
+  '#8e7cc3',
+  '#c27ba0',
+]
+
+interface EditorFullState {
+  text: string
+  selectedText: string
+  selection: { start: number; end: number }
+}
+
+// 정렬 span 제거: 이미 적용된 text-align span을 벗겨냄
+function stripAlignSpan(text: string): string {
+  return text.replace(
+    /^<span style="display: block; text-align: (?:left|center|right|justify)">([\s\S]*)<\/span>$/,
+    '$1'
+  )
+}
+
+// 줄간격 span 제거
+function stripLineHeightSpan(text: string): string {
+  return text.replace(
+    /^<span style="display: block; line-height: [\d.]+">([\s\S]*)<\/span>$/,
+    '$1'
+  )
+}
+
+// 언더라인 토글: 이미 <u>로 감싸져 있으면 제거, 아니면 추가
+function toggleUnderline(text: string): string {
+  if (/^<u>[\s\S]*<\/u>$/.test(text)) {
+    return text.replace(/^<u>([\s\S]*)<\/u>$/, '$1')
+  }
+  return `<u>${text}</u>`
+}
+
+const PILL: React.CSSProperties = {
+  borderRadius: 6,
+  background: '#f0f2f5',
+  border: '1px solid #e2e8f0',
+  padding: '0 10px',
+  height: 26,
+  width: 'auto',
+  minWidth: 'auto',
+  fontSize: 12,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+  cursor: 'pointer',
+  color: '#374151',
+  fontWeight: 400,
+}
+
+function safeSelected(
+  getState?: () => false | { selectedText: string }
+): string {
+  const s = getState?.()
+  return (s && 'selectedText' in s ? s.selectedText : '') || ''
+}
+
+const fontFamilyCommand: ICommand = {
+  name: 'font-family',
+  keyCommand: 'group',
+  groupName: 'font-family',
+  buttonProps: { 'aria-label': '글꼴', title: '글꼴', style: PILL },
+  icon: (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+      기본서체 <ChevronDown size={10} />
+    </span>
+  ),
+  children: ({ close, getState, textApi }) => (
+    <div className="toolbar-popup">
+      {FONT_FAMILIES.map(({ label, value }) => (
+        <button
+          key={value}
+          type="button"
+          style={{ fontFamily: value === 'inherit' ? undefined : value }}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => {
+            const inner = safeSelected(getState)
+            const stripped = inner.replace(
+              /^<span style="font-family: [^"]*">([\s\S]*)<\/span>$/,
+              '$1'
+            )
+            textApi?.replaceSelection(
+              `<span style="font-family: ${value}">${stripped}</span>`
+            )
+            close()
+          }}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  ),
+  execute: () => {},
+}
+
+const fontSizeCommand: ICommand = {
+  name: 'font-size',
+  keyCommand: 'group',
+  groupName: 'font-size',
+  buttonProps: { 'aria-label': '글자 크기', title: '글자 크기', style: PILL },
+  icon: (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+      16 <ChevronDown size={10} />
+    </span>
+  ),
+  children: ({ close, getState, textApi }) => (
+    <div className="toolbar-popup" style={{ minWidth: 60 }}>
+      {FONT_SIZES.map((size) => (
+        <button
+          key={size}
+          type="button"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => {
+            const inner = safeSelected(getState)
+            const stripped = inner.replace(
+              /^<span style="font-size: \d+px">([\s\S]*)<\/span>$/,
+              '$1'
+            )
+            textApi?.replaceSelection(
+              `<span style="font-size: ${size}px">${stripped}</span>`
+            )
+            close()
+          }}
+        >
+          {size}
+        </button>
+      ))}
+    </div>
+  ),
+  execute: () => {},
+}
+
+const underlineCommand: ICommand = {
+  name: 'underline',
+  keyCommand: 'underline',
+  buttonProps: { 'aria-label': '밑줄', title: '밑줄' },
+  icon: <Underline size={14} />,
+  execute: (state, api) => {
+    api.replaceSelection(toggleUnderline(state.selectedText))
+  },
+}
+
+// ~~markdown~~ 대신 <del> HTML을 사용 — markdown 취소선은 HTML 태그와 섞이면 파서가 깨짐
+const strikethroughCommand: ICommand = {
+  name: 'strikethrough',
+  keyCommand: 'strikethrough',
+  buttonProps: { 'aria-label': '취소선', title: '취소선' },
+  icon: <Strikethrough size={14} />,
+  execute: (state, api) => {
+    const sel = state.selectedText
+    if (/^<del>[\s\S]*<\/del>$/.test(sel)) {
+      api.replaceSelection(sel.replace(/^<del>([\s\S]*)<\/del>$/, '$1'))
+    } else {
+      api.replaceSelection(`<del>${sel}</del>`)
+    }
+  },
+}
+
+const BG_PALETTE_COLORS = ['#ffffff', ...PALETTE_COLORS]
+const TEXT_PALETTE_COLORS = ['#ffffff', ...PALETTE_COLORS]
+
+const bgColorCommand: ICommand = {
+  name: 'bg-color',
+  keyCommand: 'group',
+  groupName: 'bg-color',
+  buttonProps: { 'aria-label': '배경색', title: '배경색' },
+  icon: (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+      <span
+        style={{
+          width: 16,
+          height: 16,
+          borderRadius: 3,
+          background: '#4285f4',
+          border: '1px solid rgba(0,0,0,0.12)',
+          display: 'inline-block',
+        }}
+      />
+      <ChevronDown size={10} />
+    </span>
+  ),
+  children: ({ close, getState, textApi }) => (
+    <div style={{ padding: 7 }}>
+      <button
+        type="button"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => {
+          const selected = safeSelected(getState)
+          textApi?.replaceSelection(
+            selected.replace(/<mark[^>]*>([\s\S]*?)<\/mark>/g, '$1')
+          )
+          close()
+        }}
+        style={{
+          display: 'block',
+          width: '100%',
+          textAlign: 'center',
+          padding: '4px 8px',
+          marginBottom: 6,
+          fontSize: 12,
+          cursor: 'pointer',
+          border: '1px solid #e2e8f0',
+          borderRadius: 4,
+          background: 'transparent',
+          color: '#374151',
+        }}
+      >
+        배경색 제거
+      </button>
+      <div className="color-palette" style={{ padding: 0 }}>
+        {BG_PALETTE_COLORS.map((color) => (
+          <div
+            key={color}
+            className="color-swatch"
+            style={{
+              background: color,
+              border:
+                color === '#ffffff'
+                  ? '1px solid #d1d5db'
+                  : '1px solid rgba(0,0,0,0.12)',
+            }}
+            title={color}
+            onClick={() => {
+              const state = getState?.() as false | EditorFullState | undefined
+              if (!state) {
+                close?.()
+                return
+              }
+              const { text, selectedText, selection } = state
+              const before = text.substring(0, selection.start)
+              const after = text.substring(selection.end)
+              // 선택 영역이 이미 mark 태그 안에 있는 경우: 선택을 mark 전체로 확장 후 교체
+              const beforeMark = before.match(
+                /<mark style="background-color: [^"]*">$/
+              )
+              const afterMark = after.match(/^<\/mark>/)
+              if (beforeMark && afterMark) {
+                textApi?.setSelectionRange({
+                  start: selection.start - beforeMark[0].length,
+                  end: selection.end + afterMark[0].length,
+                })
+                textApi?.replaceSelection(
+                  `<mark style="background-color: ${color}">${selectedText}</mark>`
+                )
+              } else {
+                // 선택 안에 mark 태그가 포함된 경우: 모두 벗기고 새 색상 적용
+                const stripped = selectedText.replace(/<\/?mark[^>]*>/g, '')
+                textApi?.replaceSelection(
+                  `<mark style="background-color: ${color}">${stripped}</mark>`
+                )
+              }
+              close()
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  ),
+  execute: () => {},
+}
+
+const TEXT_COLOR_SPAN_RE = /^<span style="color: [^"]*">$/
+
+const textColorCommand: ICommand = {
+  name: 'text-color',
+  keyCommand: 'group',
+  groupName: 'text-color',
+  buttonProps: { 'aria-label': '글자색', title: '글자색' },
+  icon: (
+    <span
+      style={{
+        display: 'inline-flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 2,
+        lineHeight: 1,
+      }}
+    >
+      <span style={{ fontWeight: 700, fontSize: 13 }}>A</span>
+      <span
+        style={{
+          width: 14,
+          height: 3,
+          background: '#e53e3e',
+          borderRadius: 1,
+          display: 'block',
+        }}
+      />
+    </span>
+  ),
+  children: ({ close, getState, textApi }) => (
+    <div className="color-palette">
+      {TEXT_PALETTE_COLORS.map((color) => (
+        <div
+          key={color}
+          className="color-swatch"
+          style={{
+            background: color,
+            border:
+              color === '#ffffff'
+                ? '1px solid #d1d5db'
+                : '1px solid rgba(0,0,0,0.12)',
+          }}
+          title={color}
+          onClick={() => {
+            const state = getState?.() as false | EditorFullState | undefined
+            if (!state) {
+              close?.()
+              return
+            }
+            const { text, selectedText, selection } = state
+            const before = text.substring(0, selection.start)
+            const after = text.substring(selection.end)
+            // 선택 영역이 color span 안에 있는 경우: span 전체로 확장 후 교체
+            const beforeSpan = before.match(/<span style="color: [^"]*">$/)
+            const afterSpan = after.match(/^<\/span>/)
+            if (
+              beforeSpan &&
+              TEXT_COLOR_SPAN_RE.test(beforeSpan[0]) &&
+              afterSpan
+            ) {
+              textApi?.setSelectionRange({
+                start: selection.start - beforeSpan[0].length,
+                end: selection.end + afterSpan[0].length,
+              })
+              textApi?.replaceSelection(
+                `<span style="color: ${color}">${selectedText}</span>`
+              )
+            } else {
+              // 선택 안에 color span이 있는 경우: 모두 벗기고 새 색상 적용
+              const stripped = selectedText.replace(
+                /<span style="color: [^"]*">([\s\S]*?)<\/span>/g,
+                '$1'
+              )
+              textApi?.replaceSelection(
+                `<span style="color: ${color}">${stripped}</span>`
+              )
+            }
+            close()
+          }}
+        />
+      ))}
+    </div>
+  ),
+  execute: () => {},
+}
+
+const alignLeftCommand: ICommand = {
+  name: 'align-left',
+  keyCommand: 'align-left',
+  buttonProps: { 'aria-label': '왼쪽 정렬', title: '왼쪽 정렬' },
+  icon: <AlignLeft size={14} />,
+  execute: (state, api) => {
+    const sel = state.selectedText
+    if (/^<span style="display: block; text-align: left">/.test(sel)) {
+      api.replaceSelection(stripAlignSpan(sel))
+    } else {
+      api.replaceSelection(
+        `<span style="display: block; text-align: left">${stripAlignSpan(sel)}</span>`
+      )
+    }
+  },
+}
+
+const alignCenterCommand: ICommand = {
+  name: 'align-center',
+  keyCommand: 'align-center',
+  buttonProps: { 'aria-label': '가운데 정렬', title: '가운데 정렬' },
+  icon: <AlignCenter size={14} />,
+  execute: (state, api) => {
+    const sel = state.selectedText
+    if (/^<span style="display: block; text-align: center">/.test(sel)) {
+      api.replaceSelection(stripAlignSpan(sel))
+    } else {
+      api.replaceSelection(
+        `<span style="display: block; text-align: center">${stripAlignSpan(sel)}</span>`
+      )
+    }
+  },
+}
+
+const alignRightCommand: ICommand = {
+  name: 'align-right',
+  keyCommand: 'align-right',
+  buttonProps: { 'aria-label': '오른쪽 정렬', title: '오른쪽 정렬' },
+  icon: <AlignRight size={14} />,
+  execute: (state, api) => {
+    const sel = state.selectedText
+    if (/^<span style="display: block; text-align: right">/.test(sel)) {
+      api.replaceSelection(stripAlignSpan(sel))
+    } else {
+      api.replaceSelection(
+        `<span style="display: block; text-align: right">${stripAlignSpan(sel)}</span>`
+      )
+    }
+  },
+}
+
+const alignJustifyCommand: ICommand = {
+  name: 'align-justify',
+  keyCommand: 'align-justify',
+  buttonProps: { 'aria-label': '양쪽 정렬', title: '양쪽 정렬' },
+  icon: <AlignJustify size={14} />,
+  execute: (state, api) => {
+    const sel = state.selectedText
+    if (/^<span style="display: block; text-align: justify">/.test(sel)) {
+      api.replaceSelection(stripAlignSpan(sel))
+    } else {
+      api.replaceSelection(
+        `<span style="display: block; text-align: justify">${stripAlignSpan(sel)}</span>`
+      )
+    }
+  },
+}
+
+const listDropdownCmd: ICommand = {
+  name: 'list-style',
+  keyCommand: 'group',
+  groupName: 'list-style',
+  buttonProps: { 'aria-label': '목록', title: '목록' },
+  icon: (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+      <List size={13} />
+      <ChevronDown size={10} />
+    </span>
+  ),
+  children: ({ close, getState, textApi }) => (
+    <div className="toolbar-popup">
+      <button
+        type="button"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => {
+          const text = safeSelected(getState)
+          const lines = text
+            ? text
+                .split('\n')
+                .map((l) => `- ${l}`)
+                .join('\n')
+            : '- '
+          textApi?.replaceSelection(lines)
+          close()
+        }}
+      >
+        글머리 목록
+      </button>
+      <button
+        type="button"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => {
+          const text = safeSelected(getState)
+          const lines = text
+            ? text
+                .split('\n')
+                .map((l, i) => `${i + 1}. ${l}`)
+                .join('\n')
+            : '1. '
+          textApi?.replaceSelection(lines)
+          close()
+        }}
+      >
+        번호 목록
+      </button>
+      <button
+        type="button"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => {
+          const text = safeSelected(getState)
+          const lines = text
+            ? text
+                .split('\n')
+                .map((l) => `- [ ] ${l}`)
+                .join('\n')
+            : '- [ ] '
+          textApi?.replaceSelection(lines)
+          close()
+        }}
+      >
+        체크 목록
+      </button>
+    </div>
+  ),
+  execute: () => {},
+}
+
+const lineHeightCmd: ICommand = {
+  name: 'line-height',
+  keyCommand: 'group',
+  groupName: 'line-height',
+  buttonProps: { 'aria-label': '줄 간격', title: '줄 간격' },
+  icon: <ArrowUpDown size={14} />,
+  children: ({ close, getState, textApi }) => (
+    <div className="toolbar-popup" style={{ minWidth: 80 }}>
+      {['1', '1.5', '2', '2.5', '3'].map((h) => (
+        <button
+          key={h}
+          type="button"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => {
+            const text = safeSelected(getState)
+            const stripped = stripLineHeightSpan(text)
+            textApi?.replaceSelection(
+              `<span style="display: block; line-height: ${h}">${stripped}</span>`
+            )
+            close()
+          }}
+        >
+          {h}배
+        </button>
+      ))}
+    </div>
+  ),
+  execute: () => {},
+}
+
+const outdentCmd: ICommand = {
+  name: 'outdent',
+  keyCommand: 'outdent',
+  buttonProps: { 'aria-label': '내어쓰기', title: '내어쓰기' },
+  icon: <IndentDecrease size={14} />,
+  execute: (state, api) => {
+    const lines = state.selectedText
+      ? state.selectedText
+          .split('\n')
+          .map((l) => (l.startsWith('  ') ? l.slice(2) : l))
+          .join('\n')
+      : ''
+    api.replaceSelection(lines)
+  },
+}
+
+const indentCmd: ICommand = {
+  name: 'indent',
+  keyCommand: 'indent',
+  buttonProps: { 'aria-label': '들여쓰기', title: '들여쓰기' },
+  icon: <IndentIncrease size={14} />,
+  execute: (state, api) => {
+    const lines = state.selectedText
+      ? state.selectedText
+          .split('\n')
+          .map((l) => `  ${l}`)
+          .join('\n')
+      : '  '
+    api.replaceSelection(lines)
+  },
+}
+
+const clearFormatCmd: ICommand = {
+  name: 'clear-format',
+  keyCommand: 'clear-format',
+  buttonProps: { 'aria-label': '서식 제거', title: '서식 제거' },
+  icon: <RemoveFormatting size={14} />,
+  execute: (state, api) => {
+    if (!state.selectedText) return
+    const cleaned = state.selectedText
+      .replace(/\*\*(.*?)\*\*/gs, '$1')
+      .replace(/\*(.*?)\*/gs, '$1')
+      .replace(/<[^>]+>/gs, '')
+    api.replaceSelection(cleaned)
+  },
+}
 
 const UNDO_LIMIT = 50
 
@@ -79,7 +687,7 @@ export function MarkdownEditor({
         title: '실행 취소',
         'data-inactive': undoStack.length === 0 ? 'true' : undefined,
       } as React.ButtonHTMLAttributes<HTMLButtonElement>,
-      icon: <span style={{ fontSize: 13 }}>↩</span>,
+      icon: <Undo2 size={14} />,
       execute: handleUndo,
     }),
     [undoStack.length, handleUndo]
@@ -94,7 +702,7 @@ export function MarkdownEditor({
         title: '다시 실행',
         'data-inactive': redoStack.length === 0 ? 'true' : undefined,
       } as React.ButtonHTMLAttributes<HTMLButtonElement>,
-      icon: <span style={{ fontSize: 13 }}>↪</span>,
+      icon: <Redo2 size={14} />,
       execute: handleRedo,
     }),
     [redoStack.length, handleRedo]
@@ -132,7 +740,7 @@ export function MarkdownEditor({
           api.replaceSelection(`![${file.name}](${objectUrl})`)
           try {
             const serverUrl = await onImageUpload(file)
-            onChange(valueRef.current.replaceAll(objectUrl, serverUrl))
+            handleChange(valueRef.current.replaceAll(objectUrl, serverUrl))
             URL.revokeObjectURL(objectUrl)
             objectUrlsRef.current.delete(objectUrl)
           } catch {
@@ -146,7 +754,7 @@ export function MarkdownEditor({
         input.click()
       },
     }),
-    [onImageUpload, onChange]
+    [onImageUpload, handleChange]
   )
 
   const editorCommands: ICommand[] = useMemo(
@@ -154,11 +762,15 @@ export function MarkdownEditor({
       undoCommand,
       redoCommand,
       mdCommands.divider,
+      fontFamilyCommand,
+      fontSizeCommand,
+      mdCommands.divider,
       mdCommands.bold,
       mdCommands.italic,
-      mdCommands.strikethrough,
-      mdCommands.divider,
-      mdCommands.title,
+      underlineCommand,
+      strikethroughCommand,
+      bgColorCommand,
+      textColorCommand,
       mdCommands.divider,
       mdCommands.link,
       imageCommand,
@@ -168,17 +780,16 @@ export function MarkdownEditor({
 
   const editorExtraCommands: ICommand[] = useMemo(
     () => [
-      mdCommands.unorderedListCommand,
-      mdCommands.orderedListCommand,
-      mdCommands.checkedListCommand,
+      listDropdownCmd,
       mdCommands.divider,
-      mdCommands.quote,
-      mdCommands.hr,
-      mdCommands.divider,
-      mdCommands.code,
-      mdCommands.codeBlock,
-      mdCommands.divider,
-      mdCommands.table,
+      alignLeftCommand,
+      alignCenterCommand,
+      alignRightCommand,
+      alignJustifyCommand,
+      lineHeightCmd,
+      outdentCmd,
+      indentCmd,
+      clearFormatCmd,
     ],
     []
   )
@@ -194,6 +805,21 @@ export function MarkdownEditor({
           extraCommands={editorExtraCommands}
           textareaProps={{
             onKeyDown: (e) => {
+              if (e.shiftKey && e.key === 'Enter') {
+                e.preventDefault()
+                const textarea = e.currentTarget
+                const start = textarea.selectionStart
+                const end = textarea.selectionEnd
+                const insert = '<br>\n'
+                const current = textarea.value
+                const next =
+                  current.substring(0, start) + insert + current.substring(end)
+                handleChange(next)
+                requestAnimationFrame(() => {
+                  textarea.selectionStart = start + insert.length
+                  textarea.selectionEnd = start + insert.length
+                })
+              }
               if (e.key === 'Tab') {
                 e.preventDefault()
                 const textarea = e.currentTarget

--- a/src/components/community/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.tsx
@@ -3,22 +3,6 @@ import MDEditor, {
   commands as mdCommands,
   type ICommand,
 } from '@uiw/react-md-editor'
-import {
-  Undo2,
-  Redo2,
-  Underline,
-  Strikethrough,
-  AlignLeft,
-  AlignCenter,
-  AlignRight,
-  AlignJustify,
-  List,
-  ChevronDown,
-  ArrowUpDown,
-  RemoveFormatting,
-  IndentIncrease,
-  IndentDecrease,
-} from 'lucide-react'
 import './MarkdownEditor.css'
 
 export interface MarkdownEditorProps {
@@ -34,598 +18,6 @@ const ACCEPTED_IMAGE_TYPES = [
   'image/gif',
   'image/webp',
 ]
-
-const FONT_FAMILIES = [
-  { label: '기본서체', value: 'inherit' },
-  { label: 'Arial', value: 'Arial, sans-serif' },
-  { label: '돋움', value: 'Dotum, sans-serif' },
-  { label: '맑은 고딕', value: "'Malgun Gothic', sans-serif" },
-  { label: 'Georgia', value: 'Georgia, serif' },
-  { label: 'Courier New', value: "'Courier New', monospace" },
-]
-
-const FONT_SIZES = [10, 12, 14, 16, 18, 20, 24, 28, 32]
-
-const PALETTE_COLORS = [
-  '#000000',
-  '#434343',
-  '#666666',
-  '#999999',
-  '#b7b7b7',
-  '#ff0000',
-  '#ff7700',
-  '#ffff00',
-  '#00ff00',
-  '#0000ff',
-  '#9900ff',
-  '#ff00ff',
-  '#00ffff',
-  '#ff6d6d',
-  '#ffd966',
-  '#93c47d',
-  '#76a5af',
-  '#4a86e8',
-  '#8e7cc3',
-  '#c27ba0',
-]
-
-interface EditorFullState {
-  text: string
-  selectedText: string
-  selection: { start: number; end: number }
-}
-
-// 정렬 span 제거: 이미 적용된 text-align span을 벗겨냄
-function stripAlignSpan(text: string): string {
-  return text.replace(
-    /^<span style="display: block; text-align: (?:left|center|right|justify)">([\s\S]*)<\/span>$/,
-    '$1'
-  )
-}
-
-// 줄간격 span 제거
-function stripLineHeightSpan(text: string): string {
-  return text.replace(
-    /^<span style="display: block; line-height: [\d.]+">([\s\S]*)<\/span>$/,
-    '$1'
-  )
-}
-
-// 언더라인 토글: 이미 <u>로 감싸져 있으면 제거, 아니면 추가
-function toggleUnderline(text: string): string {
-  if (/^<u>[\s\S]*<\/u>$/.test(text)) {
-    return text.replace(/^<u>([\s\S]*)<\/u>$/, '$1')
-  }
-  return `<u>${text}</u>`
-}
-
-const PILL: React.CSSProperties = {
-  borderRadius: 6,
-  background: '#f0f2f5',
-  border: '1px solid #e2e8f0',
-  padding: '0 10px',
-  height: 26,
-  width: 'auto',
-  minWidth: 'auto',
-  fontSize: 12,
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 4,
-  cursor: 'pointer',
-  color: '#374151',
-  fontWeight: 400,
-}
-
-function safeSelected(
-  getState?: () => false | { selectedText: string }
-): string {
-  const s = getState?.()
-  return (s && 'selectedText' in s ? s.selectedText : '') || ''
-}
-
-const fontFamilyCommand: ICommand = {
-  name: 'font-family',
-  keyCommand: 'group',
-  groupName: 'font-family',
-  buttonProps: { 'aria-label': '글꼴', title: '글꼴', style: PILL },
-  icon: (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-      기본서체 <ChevronDown size={10} />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup">
-      {FONT_FAMILIES.map(({ label, value }) => (
-        <button
-          key={value}
-          type="button"
-          style={{ fontFamily: value === 'inherit' ? undefined : value }}
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={() => {
-            const inner = safeSelected(getState)
-            const stripped = inner.replace(
-              /^<span style="font-family: [^"]*">([\s\S]*)<\/span>$/,
-              '$1'
-            )
-            textApi?.replaceSelection(
-              `<span style="font-family: ${value}">${stripped}</span>`
-            )
-            close()
-          }}
-        >
-          {label}
-        </button>
-      ))}
-    </div>
-  ),
-  execute: () => {},
-}
-
-const fontSizeCommand: ICommand = {
-  name: 'font-size',
-  keyCommand: 'group',
-  groupName: 'font-size',
-  buttonProps: { 'aria-label': '글자 크기', title: '글자 크기', style: PILL },
-  icon: (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-      16 <ChevronDown size={10} />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup" style={{ minWidth: 60 }}>
-      {FONT_SIZES.map((size) => (
-        <button
-          key={size}
-          type="button"
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={() => {
-            const inner = safeSelected(getState)
-            const stripped = inner.replace(
-              /^<span style="font-size: \d+px">([\s\S]*)<\/span>$/,
-              '$1'
-            )
-            textApi?.replaceSelection(
-              `<span style="font-size: ${size}px">${stripped}</span>`
-            )
-            close()
-          }}
-        >
-          {size}
-        </button>
-      ))}
-    </div>
-  ),
-  execute: () => {},
-}
-
-const underlineCommand: ICommand = {
-  name: 'underline',
-  keyCommand: 'underline',
-  buttonProps: { 'aria-label': '밑줄', title: '밑줄' },
-  icon: <Underline size={14} />,
-  execute: (state, api) => {
-    api.replaceSelection(toggleUnderline(state.selectedText))
-  },
-}
-
-// ~~markdown~~ 대신 <del> HTML을 사용 — markdown 취소선은 HTML 태그와 섞이면 파서가 깨짐
-const strikethroughCommand: ICommand = {
-  name: 'strikethrough',
-  keyCommand: 'strikethrough',
-  buttonProps: { 'aria-label': '취소선', title: '취소선' },
-  icon: <Strikethrough size={14} />,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    if (/^<del>[\s\S]*<\/del>$/.test(sel)) {
-      api.replaceSelection(sel.replace(/^<del>([\s\S]*)<\/del>$/, '$1'))
-    } else {
-      api.replaceSelection(`<del>${sel}</del>`)
-    }
-  },
-}
-
-const BG_PALETTE_COLORS = ['#ffffff', ...PALETTE_COLORS]
-const TEXT_PALETTE_COLORS = ['#ffffff', ...PALETTE_COLORS]
-
-const bgColorCommand: ICommand = {
-  name: 'bg-color',
-  keyCommand: 'group',
-  groupName: 'bg-color',
-  buttonProps: { 'aria-label': '배경색', title: '배경색' },
-  icon: (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-      <span
-        style={{
-          width: 16,
-          height: 16,
-          borderRadius: 3,
-          background: '#4285f4',
-          border: '1px solid rgba(0,0,0,0.12)',
-          display: 'inline-block',
-        }}
-      />
-      <ChevronDown size={10} />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div style={{ padding: 7 }}>
-      <button
-        type="button"
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => {
-          const selected = safeSelected(getState)
-          textApi?.replaceSelection(
-            selected.replace(/<mark[^>]*>([\s\S]*?)<\/mark>/g, '$1')
-          )
-          close()
-        }}
-        style={{
-          display: 'block',
-          width: '100%',
-          textAlign: 'center',
-          padding: '4px 8px',
-          marginBottom: 6,
-          fontSize: 12,
-          cursor: 'pointer',
-          border: '1px solid #e2e8f0',
-          borderRadius: 4,
-          background: 'transparent',
-          color: '#374151',
-        }}
-      >
-        배경색 제거
-      </button>
-      <div className="color-palette" style={{ padding: 0 }}>
-        {BG_PALETTE_COLORS.map((color) => (
-          <div
-            key={color}
-            className="color-swatch"
-            style={{
-              background: color,
-              border:
-                color === '#ffffff'
-                  ? '1px solid #d1d5db'
-                  : '1px solid rgba(0,0,0,0.12)',
-            }}
-            title={color}
-            onClick={() => {
-              const state = getState?.() as false | EditorFullState | undefined
-              if (!state) {
-                close?.()
-                return
-              }
-              const { text, selectedText, selection } = state
-              const before = text.substring(0, selection.start)
-              const after = text.substring(selection.end)
-              // 선택 영역이 이미 mark 태그 안에 있는 경우: 선택을 mark 전체로 확장 후 교체
-              const beforeMark = before.match(
-                /<mark style="background-color: [^"]*">$/
-              )
-              const afterMark = after.match(/^<\/mark>/)
-              if (beforeMark && afterMark) {
-                textApi?.setSelectionRange({
-                  start: selection.start - beforeMark[0].length,
-                  end: selection.end + afterMark[0].length,
-                })
-                textApi?.replaceSelection(
-                  `<mark style="background-color: ${color}">${selectedText}</mark>`
-                )
-              } else {
-                // 선택 안에 mark 태그가 포함된 경우: 모두 벗기고 새 색상 적용
-                const stripped = selectedText.replace(/<\/?mark[^>]*>/g, '')
-                textApi?.replaceSelection(
-                  `<mark style="background-color: ${color}">${stripped}</mark>`
-                )
-              }
-              close()
-            }}
-          />
-        ))}
-      </div>
-    </div>
-  ),
-  execute: () => {},
-}
-
-const TEXT_COLOR_SPAN_RE = /^<span style="color: [^"]*">$/
-
-const textColorCommand: ICommand = {
-  name: 'text-color',
-  keyCommand: 'group',
-  groupName: 'text-color',
-  buttonProps: { 'aria-label': '글자색', title: '글자색' },
-  icon: (
-    <span
-      style={{
-        display: 'inline-flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        gap: 2,
-        lineHeight: 1,
-      }}
-    >
-      <span style={{ fontWeight: 700, fontSize: 13 }}>A</span>
-      <span
-        style={{
-          width: 14,
-          height: 3,
-          background: '#e53e3e',
-          borderRadius: 1,
-          display: 'block',
-        }}
-      />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div className="color-palette">
-      {TEXT_PALETTE_COLORS.map((color) => (
-        <div
-          key={color}
-          className="color-swatch"
-          style={{
-            background: color,
-            border:
-              color === '#ffffff'
-                ? '1px solid #d1d5db'
-                : '1px solid rgba(0,0,0,0.12)',
-          }}
-          title={color}
-          onClick={() => {
-            const state = getState?.() as false | EditorFullState | undefined
-            if (!state) {
-              close?.()
-              return
-            }
-            const { text, selectedText, selection } = state
-            const before = text.substring(0, selection.start)
-            const after = text.substring(selection.end)
-            // 선택 영역이 color span 안에 있는 경우: span 전체로 확장 후 교체
-            const beforeSpan = before.match(/<span style="color: [^"]*">$/)
-            const afterSpan = after.match(/^<\/span>/)
-            if (
-              beforeSpan &&
-              TEXT_COLOR_SPAN_RE.test(beforeSpan[0]) &&
-              afterSpan
-            ) {
-              textApi?.setSelectionRange({
-                start: selection.start - beforeSpan[0].length,
-                end: selection.end + afterSpan[0].length,
-              })
-              textApi?.replaceSelection(
-                `<span style="color: ${color}">${selectedText}</span>`
-              )
-            } else {
-              // 선택 안에 color span이 있는 경우: 모두 벗기고 새 색상 적용
-              const stripped = selectedText.replace(
-                /<span style="color: [^"]*">([\s\S]*?)<\/span>/g,
-                '$1'
-              )
-              textApi?.replaceSelection(
-                `<span style="color: ${color}">${stripped}</span>`
-              )
-            }
-            close()
-          }}
-        />
-      ))}
-    </div>
-  ),
-  execute: () => {},
-}
-
-const alignLeftCommand: ICommand = {
-  name: 'align-left',
-  keyCommand: 'align-left',
-  buttonProps: { 'aria-label': '왼쪽 정렬', title: '왼쪽 정렬' },
-  icon: <AlignLeft size={14} />,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    if (/^<span style="display: block; text-align: left">/.test(sel)) {
-      api.replaceSelection(stripAlignSpan(sel))
-    } else {
-      api.replaceSelection(
-        `<span style="display: block; text-align: left">${stripAlignSpan(sel)}</span>`
-      )
-    }
-  },
-}
-
-const alignCenterCommand: ICommand = {
-  name: 'align-center',
-  keyCommand: 'align-center',
-  buttonProps: { 'aria-label': '가운데 정렬', title: '가운데 정렬' },
-  icon: <AlignCenter size={14} />,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    if (/^<span style="display: block; text-align: center">/.test(sel)) {
-      api.replaceSelection(stripAlignSpan(sel))
-    } else {
-      api.replaceSelection(
-        `<span style="display: block; text-align: center">${stripAlignSpan(sel)}</span>`
-      )
-    }
-  },
-}
-
-const alignRightCommand: ICommand = {
-  name: 'align-right',
-  keyCommand: 'align-right',
-  buttonProps: { 'aria-label': '오른쪽 정렬', title: '오른쪽 정렬' },
-  icon: <AlignRight size={14} />,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    if (/^<span style="display: block; text-align: right">/.test(sel)) {
-      api.replaceSelection(stripAlignSpan(sel))
-    } else {
-      api.replaceSelection(
-        `<span style="display: block; text-align: right">${stripAlignSpan(sel)}</span>`
-      )
-    }
-  },
-}
-
-const alignJustifyCommand: ICommand = {
-  name: 'align-justify',
-  keyCommand: 'align-justify',
-  buttonProps: { 'aria-label': '양쪽 정렬', title: '양쪽 정렬' },
-  icon: <AlignJustify size={14} />,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    if (/^<span style="display: block; text-align: justify">/.test(sel)) {
-      api.replaceSelection(stripAlignSpan(sel))
-    } else {
-      api.replaceSelection(
-        `<span style="display: block; text-align: justify">${stripAlignSpan(sel)}</span>`
-      )
-    }
-  },
-}
-
-const listDropdownCmd: ICommand = {
-  name: 'list-style',
-  keyCommand: 'group',
-  groupName: 'list-style',
-  buttonProps: { 'aria-label': '목록', title: '목록' },
-  icon: (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
-      <List size={13} />
-      <ChevronDown size={10} />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup">
-      <button
-        type="button"
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => {
-          const text = safeSelected(getState)
-          const lines = text
-            ? text
-                .split('\n')
-                .map((l) => `- ${l}`)
-                .join('\n')
-            : '- '
-          textApi?.replaceSelection(lines)
-          close()
-        }}
-      >
-        글머리 목록
-      </button>
-      <button
-        type="button"
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => {
-          const text = safeSelected(getState)
-          const lines = text
-            ? text
-                .split('\n')
-                .map((l, i) => `${i + 1}. ${l}`)
-                .join('\n')
-            : '1. '
-          textApi?.replaceSelection(lines)
-          close()
-        }}
-      >
-        번호 목록
-      </button>
-      <button
-        type="button"
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => {
-          const text = safeSelected(getState)
-          const lines = text
-            ? text
-                .split('\n')
-                .map((l) => `- [ ] ${l}`)
-                .join('\n')
-            : '- [ ] '
-          textApi?.replaceSelection(lines)
-          close()
-        }}
-      >
-        체크 목록
-      </button>
-    </div>
-  ),
-  execute: () => {},
-}
-
-const lineHeightCmd: ICommand = {
-  name: 'line-height',
-  keyCommand: 'group',
-  groupName: 'line-height',
-  buttonProps: { 'aria-label': '줄 간격', title: '줄 간격' },
-  icon: <ArrowUpDown size={14} />,
-  children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup" style={{ minWidth: 80 }}>
-      {['1', '1.5', '2', '2.5', '3'].map((h) => (
-        <button
-          key={h}
-          type="button"
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={() => {
-            const text = safeSelected(getState)
-            const stripped = stripLineHeightSpan(text)
-            textApi?.replaceSelection(
-              `<span style="display: block; line-height: ${h}">${stripped}</span>`
-            )
-            close()
-          }}
-        >
-          {h}배
-        </button>
-      ))}
-    </div>
-  ),
-  execute: () => {},
-}
-
-const outdentCmd: ICommand = {
-  name: 'outdent',
-  keyCommand: 'outdent',
-  buttonProps: { 'aria-label': '내어쓰기', title: '내어쓰기' },
-  icon: <IndentDecrease size={14} />,
-  execute: (state, api) => {
-    const lines = state.selectedText
-      ? state.selectedText
-          .split('\n')
-          .map((l) => (l.startsWith('  ') ? l.slice(2) : l))
-          .join('\n')
-      : ''
-    api.replaceSelection(lines)
-  },
-}
-
-const indentCmd: ICommand = {
-  name: 'indent',
-  keyCommand: 'indent',
-  buttonProps: { 'aria-label': '들여쓰기', title: '들여쓰기' },
-  icon: <IndentIncrease size={14} />,
-  execute: (state, api) => {
-    const lines = state.selectedText
-      ? state.selectedText
-          .split('\n')
-          .map((l) => `  ${l}`)
-          .join('\n')
-      : '  '
-    api.replaceSelection(lines)
-  },
-}
-
-const clearFormatCmd: ICommand = {
-  name: 'clear-format',
-  keyCommand: 'clear-format',
-  buttonProps: { 'aria-label': '서식 제거', title: '서식 제거' },
-  icon: <RemoveFormatting size={14} />,
-  execute: (state, api) => {
-    if (!state.selectedText) return
-    const cleaned = state.selectedText
-      .replace(/\*\*(.*?)\*\*/gs, '$1')
-      .replace(/\*(.*?)\*/gs, '$1')
-      .replace(/<[^>]+>/gs, '')
-    api.replaceSelection(cleaned)
-  },
-}
 
 const UNDO_LIMIT = 50
 
@@ -687,7 +79,7 @@ export function MarkdownEditor({
         title: '실행 취소',
         'data-inactive': undoStack.length === 0 ? 'true' : undefined,
       } as React.ButtonHTMLAttributes<HTMLButtonElement>,
-      icon: <Undo2 size={14} />,
+      icon: <span style={{ fontSize: 13 }}>↩</span>,
       execute: handleUndo,
     }),
     [undoStack.length, handleUndo]
@@ -702,7 +94,7 @@ export function MarkdownEditor({
         title: '다시 실행',
         'data-inactive': redoStack.length === 0 ? 'true' : undefined,
       } as React.ButtonHTMLAttributes<HTMLButtonElement>,
-      icon: <Redo2 size={14} />,
+      icon: <span style={{ fontSize: 13 }}>↪</span>,
       execute: handleRedo,
     }),
     [redoStack.length, handleRedo]
@@ -740,7 +132,7 @@ export function MarkdownEditor({
           api.replaceSelection(`![${file.name}](${objectUrl})`)
           try {
             const serverUrl = await onImageUpload(file)
-            handleChange(valueRef.current.replaceAll(objectUrl, serverUrl))
+            onChange(valueRef.current.replaceAll(objectUrl, serverUrl))
             URL.revokeObjectURL(objectUrl)
             objectUrlsRef.current.delete(objectUrl)
           } catch {
@@ -754,7 +146,7 @@ export function MarkdownEditor({
         input.click()
       },
     }),
-    [onImageUpload, handleChange]
+    [onImageUpload, onChange]
   )
 
   const editorCommands: ICommand[] = useMemo(
@@ -762,15 +154,11 @@ export function MarkdownEditor({
       undoCommand,
       redoCommand,
       mdCommands.divider,
-      fontFamilyCommand,
-      fontSizeCommand,
-      mdCommands.divider,
       mdCommands.bold,
       mdCommands.italic,
-      underlineCommand,
-      strikethroughCommand,
-      bgColorCommand,
-      textColorCommand,
+      mdCommands.strikethrough,
+      mdCommands.divider,
+      mdCommands.title,
       mdCommands.divider,
       mdCommands.link,
       imageCommand,
@@ -780,16 +168,17 @@ export function MarkdownEditor({
 
   const editorExtraCommands: ICommand[] = useMemo(
     () => [
-      listDropdownCmd,
+      mdCommands.unorderedListCommand,
+      mdCommands.orderedListCommand,
+      mdCommands.checkedListCommand,
       mdCommands.divider,
-      alignLeftCommand,
-      alignCenterCommand,
-      alignRightCommand,
-      alignJustifyCommand,
-      lineHeightCmd,
-      outdentCmd,
-      indentCmd,
-      clearFormatCmd,
+      mdCommands.quote,
+      mdCommands.hr,
+      mdCommands.divider,
+      mdCommands.code,
+      mdCommands.codeBlock,
+      mdCommands.divider,
+      mdCommands.table,
     ],
     []
   )
@@ -805,21 +194,6 @@ export function MarkdownEditor({
           extraCommands={editorExtraCommands}
           textareaProps={{
             onKeyDown: (e) => {
-              if (e.shiftKey && e.key === 'Enter') {
-                e.preventDefault()
-                const textarea = e.currentTarget
-                const start = textarea.selectionStart
-                const end = textarea.selectionEnd
-                const insert = '<br>\n'
-                const current = textarea.value
-                const next =
-                  current.substring(0, start) + insert + current.substring(end)
-                handleChange(next)
-                requestAnimationFrame(() => {
-                  textarea.selectionStart = start + insert.length
-                  textarea.selectionEnd = start + insert.length
-                })
-              }
               if (e.key === 'Tab') {
                 e.preventDefault()
                 const textarea = e.currentTarget

--- a/src/features/accounts/me/queries.ts
+++ b/src/features/accounts/me/queries.ts
@@ -5,7 +5,8 @@ import type { MeResponse } from './types'
 export function useCurrentUser() {
   return useQuery({
     queryKey: ['accounts', 'me'],
-    queryFn: () => api.get<MeResponse>('/api/v1/accounts/me/').then((r) => r.data),
+    queryFn: () =>
+      api.get<MeResponse>('/api/v1/accounts/me/').then((r) => r.data),
     enabled: !!localStorage.getItem('accessToken'),
     staleTime: 60 * 1000,
     retry: 1,


### PR DESCRIPTION
## 관련 이슈

- closes #87

## 작업 내용

- bold/italic 서식 중복 적용 시 이전 서식이 사라지는 버그 수정
- Blockquote Enter 키 동작 구현
- 하위 리스트 Enter 키 동작 구현

## 변경 사항

- `boldCommand`: `***text***`에 bold 재적용 시 italic 유지하며 bold만 제거, `*text*`에 bold 적용 시 `***text***` 생성
- `italicCommand`: `***text***`에 italic 재적용 시 bold 유지하며 italic만 제거, `**text**`에 italic 적용 시 `***text***` 생성
- Blockquote Enter: 내용 있는 `> ` 줄 → 새 `> ` 생성 / 빈 `> ` 1·2회 → `> ` 유지 / 빈 `> ` 3회(연속 두 번째) → 일반 줄 탈출
- 하위 리스트 Enter: 내용 있는 `  - ` 줄 → 같은 레벨 `  - ` 생성 / 빈 항목 1·2회 → `  - ` 유지 / 빈 항목 3회(연속 두 번째) → 상위 `- ` 레벨 탈출

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다