### PR TITLE
refactor: MarkdownEditor 모듈 분리 및 API 인터셉터 무한 루프 수정 (#91)

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -20,6 +20,6 @@ export const baseApi = axios.create({
   withCredentials: true,
 })
 
-setupInterceptors(api, baseApi)
+setupInterceptors(api)
 
 export default api

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -6,7 +6,7 @@ const api = axios.create({
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',
-    Authorization: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzc4MzEzMTEwLCJpYXQiOjE3NzgyMjY3MTAsImp0aSI6IjY4MzA2ZTllMDM0YzQzZDVhZWE1ZTZhMjBiNzAzNzljIiwidXNlcl9pZCI6M30.iK0swBqaOi-8J1r-EbLtWEWC4XyCykuVnedKuQOtTrA`,
+    Authorization: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzc4NjY0NjQ0LCJpYXQiOjE3Nzg1NzgyNDQsImp0aSI6IjU3ZDRlZGU2MmY5YzRlYjFiMGRjYmQzMTQ3MWRkOTc5IiwidXNlcl9pZCI6Mn0.l8U1DPbqsFkMXikbe4Hh0s9nKe-ddnBijKtm6MTB8fY`,
   },
   withCredentials: true,
 })

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -4,28 +4,13 @@ import type {
   AxiosError,
 } from 'axios'
 import { useAuthStore } from '@/stores/authStore'
+import axios from 'axios'
 
 interface RetryConfig extends InternalAxiosRequestConfig {
   _retry?: boolean
 }
 
-<<<<<<< feature/markdown-editor
-const redirectToLogin = () => {
-  useAuthStore.getState().logout()
-  localStorage.removeItem('accessToken')
-
-  // if (window.location.pathname !== ROUTES.AUTH.LOGIN) {
-  //   window.location.href = ROUTES.AUTH.LOGIN
-  // }
-}
-
-export function setupInterceptors(
-  instance: AxiosInstance,
-  baseInstance: AxiosInstance
-): void {
-=======
 export function setupInterceptors(instance: AxiosInstance): void {
->>>>>>> dev
   instance.interceptors.request.use(
     (config) => {
       const token = localStorage.getItem('accessToken')
@@ -50,11 +35,6 @@ export function setupInterceptors(instance: AxiosInstance): void {
         originalConfig._retry = true
 
         try {
-<<<<<<< feature/markdown-editor
-          const { data } = await baseInstance.post(
-            '/api/v1/accounts/me/refresh',
-            {}
-=======
           const { data } = await axios.post(
             '/api/v1/accounts/me/refresh',
             {},
@@ -62,7 +42,6 @@ export function setupInterceptors(instance: AxiosInstance): void {
               baseURL: import.meta.env.VITE_API_BASE_URL,
               withCredentials: true,
             }
->>>>>>> dev
           )
 
           const newToken = data.access_token

--- a/src/components/community/MarkdownEditor/MarkdownEditor.css
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.css
@@ -1,3 +1,9 @@
+/* ── 마크다운 에디터 툴바용 웹폰트 ──
+   index.html을 건드리지 않고 CSS @import로 Google Fonts 로드.
+   로드 실패 시 FONT_FAMILIES fallback 스택의 시스템 폰트로 자동 대체됨.
+*/
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&family=Nanum+Gothic&family=Nanum+Myeongjo&family=Roboto:wght@400;700&family=Merriweather:wght@400;700&family=Source+Code+Pro:wght@400;700&display=swap');
+
 /* ── MDEditor CSS 변수 오버라이드: 외부 border/shadow 제거 ── */
 .post-editor-wrap .w-md-editor {
   --md-editor-box-shadow-color: transparent;
@@ -102,47 +108,6 @@
   opacity: 0.3 !important;
 }
 
-/* ── Tab 들여쓰기로 생성된 인덴티드 코드블록 배경 제거 ── */
-/* pre:not([class]) = 언어 미지정 코드블록 (4칸 들여쓰기 또는 언어 없는 펜싱) */
-.post-editor-wrap .wmde-markdown pre:not([class]) {
-  background-color: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
-}
-
-/* ── 목록 스타일 복원 ── */
-.post-editor-wrap .wmde-markdown ul {
-  list-style-type: disc !important;
-  padding-left: 2em !important;
-  margin: 0.5em 0 !important;
-}
-
-.post-editor-wrap .wmde-markdown ol {
-  list-style-type: decimal !important;
-  padding-left: 2em !important;
-  margin: 0.5em 0 !important;
-}
-
-.post-editor-wrap .wmde-markdown li {
-  display: list-item !important;
-}
-
-.post-editor-wrap .wmde-markdown ul ul {
-  list-style-type: circle !important;
-}
-
-.post-editor-wrap .wmde-markdown ul ul ul {
-  list-style-type: square !important;
-}
-
-.post-editor-wrap .wmde-markdown ol ol {
-  list-style-type: lower-alpha !important;
-}
-
-.post-editor-wrap .wmde-markdown ol ol ol {
-  list-style-type: lower-roman !important;
-}
-
 /* ── 헤딩 스타일 복원 ── */
 .post-editor-wrap .wmde-markdown h1 {
   font-size: 2em !important;
@@ -178,6 +143,39 @@
   color: #6b7280 !important;
 }
 
+/* ── 목록 스타일 복원 ── */
+.post-editor-wrap .wmde-markdown ul {
+  list-style-type: disc !important;
+  padding-left: 2em !important;
+  margin: 0.5em 0 !important;
+}
+.post-editor-wrap .wmde-markdown ol {
+  list-style-type: decimal !important;
+  padding-left: 2em !important;
+  margin: 0.5em 0 !important;
+}
+.post-editor-wrap .wmde-markdown li {
+  margin: 0.25em 0 !important;
+}
+.post-editor-wrap .wmde-markdown ul ul {
+  list-style-type: circle !important;
+}
+.post-editor-wrap .wmde-markdown ul ul ul {
+  list-style-type: square !important;
+}
+
+/* ── 툴바 필 버튼 아이콘 (글꼴·글자크기 드롭다운 아이콘) ── */
+.toolbar-pill-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+/* ── 글자 크기 팝업 최소 너비 ── */
+.toolbar-popup--font-size {
+  min-width: 60px;
+}
+
 /* ── 드롭다운 팝업 ── */
 .toolbar-popup {
   background: #fff;
@@ -207,6 +205,34 @@
   background: #f1f5f9;
 }
 
+/* ── 배경색 팝업 ── */
+.bg-color-popup {
+  padding: 7px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.bg-color-remove-btn {
+  display: block;
+  width: 100%;
+  margin-bottom: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  color: #374151;
+  white-space: nowrap;
+}
+
+.bg-color-remove-btn:hover {
+  background: #f1f5f9;
+}
+
 /* ── 색상 팔레트 ── */
 .color-palette {
   display: grid;
@@ -233,27 +259,7 @@
   border-color: #64748b;
 }
 
-/* ── Notion 스타일 리스트 ── */
-.post-editor-wrap .wmde-markdown ul {
-  list-style-type: disc;
-  padding-left: 1.5em;
-  margin: 0.25em 0;
-}
-
-.post-editor-wrap .wmde-markdown ul ul {
-  list-style-type: circle;
-}
-
-.post-editor-wrap .wmde-markdown ul ul ul {
-  list-style-type: square;
-}
-
-.post-editor-wrap .wmde-markdown ol {
-  list-style-type: decimal;
-  padding-left: 1.5em;
-  margin: 0.25em 0;
-}
-
-.post-editor-wrap .wmde-markdown li {
-  margin: 0.1em 0;
+/* 흰색 스와치는 배경과 구분되도록 더 진한 테두리 적용 */
+.color-swatch[data-white='true'] {
+  border-color: #cdcdcd;
 }

--- a/src/components/community/MarkdownEditor/MarkdownEditor.css
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.css
@@ -157,6 +157,9 @@
 .post-editor-wrap .wmde-markdown li {
   margin: 0.25em 0 !important;
 }
+.post-editor-wrap .wmde-markdown li > p {
+  margin: 0 !important;
+}
 .post-editor-wrap .wmde-markdown ul ul {
   list-style-type: circle !important;
 }

--- a/src/components/community/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.tsx
@@ -3,856 +3,446 @@ import MDEditor, {
   commands as mdCommands,
   type ICommand,
 } from '@uiw/react-md-editor'
-import {
-  Undo2,
-  Redo2,
-  Underline,
-  Strikethrough,
-  AlignLeft,
-  AlignCenter,
-  AlignRight,
-  AlignJustify,
-  List,
-  ChevronDown,
-  ArrowUpDown,
-  RemoveFormatting,
-  IndentIncrease,
-  IndentDecrease,
-} from 'lucide-react'
+import { ChevronDown } from 'lucide-react'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize from 'rehype-sanitize'
 import './MarkdownEditor.css'
+import {
+  editorSanitizeSchema,
+  ACCEPTED_IMAGE_TYPES,
+  FONT_FAMILIES,
+  FONT_SIZES,
+  NO_BLUR_PROPS,
+  PILL,
+  UNDO_LIMIT,
+} from './markdownEditorConstants'
+import {
+  applyInlineFromDropdown,
+  wrapWithStyle,
+  computeNextNumber,
+  renumberFrom,
+} from './markdownEditorUtils'
+import {
+  boldCommand,
+  italicCommand,
+  strikethroughCommand,
+  underlineCommand,
+  bgColorCommand,
+  textColorCommand,
+  alignLeftCommand,
+  alignCenterCommand,
+  alignRightCommand,
+  alignJustifyCommand,
+  listDropdownCmd,
+  lineHeightCmd,
+  outdentCmd,
+  indentCmd,
+  clearFormatCmd,
+} from './markdownEditorCommands'
+import { useMarkdownHistory } from './useMarkdownHistory'
+import { useImageUpload } from './useImageUpload'
 
 export interface MarkdownEditorProps {
   value: string
   onChange: (value: string) => void
-  onImageUpload?: (file: File) => Promise<string>
   error?: string
+  actions?: React.ReactNode
+  wrapperClassName?: string
 }
-
-const ACCEPTED_IMAGE_TYPES = [
-  'image/jpeg',
-  'image/png',
-  'image/gif',
-  'image/webp',
-]
-
-const FONT_FAMILIES = [
-  { label: '기본서체', value: 'inherit' },
-  { label: 'Arial', value: 'Arial, sans-serif' },
-  { label: '돋움', value: 'Dotum, sans-serif' },
-  { label: '맑은 고딕', value: "'Malgun Gothic', sans-serif" },
-  { label: 'Georgia', value: 'Georgia, serif' },
-  { label: 'Courier New', value: "'Courier New', monospace" },
-]
-
-const FONT_SIZES = [10, 12, 14, 16, 18, 20, 24, 28, 32]
-
-const PALETTE_COLORS = [
-  '#000000',
-  '#434343',
-  '#666666',
-  '#999999',
-  '#b7b7b7',
-  '#ff0000',
-  '#ff7700',
-  '#ffff00',
-  '#00ff00',
-  '#0000ff',
-  '#9900ff',
-  '#ff00ff',
-  '#00ffff',
-  '#ff6d6d',
-  '#ffd966',
-  '#93c47d',
-  '#76a5af',
-  '#4a86e8',
-  '#8e7cc3',
-  '#c27ba0',
-]
-
-interface EditorFullState {
-  text: string
-  selectedText: string
-  selection: { start: number; end: number }
-}
-
-// 정렬 span 제거: 이미 적용된 text-align span을 벗겨냄
-function stripAlignSpan(text: string): string {
-  return text.replace(
-    /^<span style="display: block; text-align: (?:left|center|right|justify)">([\s\S]*)<\/span>$/,
-    '$1'
-  )
-}
-
-// 줄간격 span 제거
-function stripLineHeightSpan(text: string): string {
-  return text.replace(
-    /^<span style="display: block; line-height: [\d.]+">([\s\S]*)<\/span>$/,
-    '$1'
-  )
-}
-
-// bold/italic 중첩 적용 시 기존 포맷 보존을 위한 감지 함수
-function detectFormat(text: string): { bold: boolean; italic: boolean } {
-  const isBoldItalic =
-    text.startsWith('***') && text.endsWith('***') && text.length >= 6
-  const isBold =
-    !isBoldItalic &&
-    text.startsWith('**') &&
-    text.endsWith('**') &&
-    text.length >= 4
-  const isItalic =
-    !isBoldItalic &&
-    !isBold &&
-    text.startsWith('*') &&
-    text.endsWith('*') &&
-    text.length >= 2
-  return { bold: isBoldItalic || isBold, italic: isBoldItalic || isItalic }
-}
-
-// 언더라인 토글: 이미 <u>로 감싸져 있으면 제거, 아니면 추가
-function toggleUnderline(text: string): string {
-  if (/^<u>[\s\S]*<\/u>$/.test(text)) {
-    return text.replace(/^<u>([\s\S]*)<\/u>$/, '$1')
-  }
-  return `<u>${text}</u>`
-}
-
-const PILL: React.CSSProperties = {
-  borderRadius: 6,
-  background: '#f0f2f5',
-  border: '1px solid #e2e8f0',
-  padding: '0 10px',
-  height: 26,
-  width: 'auto',
-  minWidth: 'auto',
-  fontSize: 12,
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 4,
-  cursor: 'pointer',
-  color: '#374151',
-  fontWeight: 400,
-}
-
-function safeSelected(
-  getState?: () => false | { selectedText: string }
-): string {
-  const s = getState?.()
-  return (s && 'selectedText' in s ? s.selectedText : '') || ''
-}
-
-const fontFamilyCommand: ICommand = {
-  name: 'font-family',
-  keyCommand: 'group',
-  groupName: 'font-family',
-  buttonProps: { 'aria-label': '글꼴', title: '글꼴', style: PILL },
-  icon: (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-      기본서체 <ChevronDown size={10} />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup">
-      {FONT_FAMILIES.map(({ label, value }) => (
-        <button
-          key={value}
-          type="button"
-          style={{ fontFamily: value === 'inherit' ? undefined : value }}
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={() => {
-            const inner = safeSelected(getState)
-            const stripped = inner.replace(
-              /^<span style="font-family: [^"]*">([\s\S]*)<\/span>$/,
-              '$1'
-            )
-            textApi?.replaceSelection(
-              `<span style="font-family: ${value}">${stripped}</span>`
-            )
-            close()
-          }}
-        >
-          {label}
-        </button>
-      ))}
-    </div>
-  ),
-  execute: () => {},
-}
-
-const fontSizeCommand: ICommand = {
-  name: 'font-size',
-  keyCommand: 'group',
-  groupName: 'font-size',
-  buttonProps: { 'aria-label': '글자 크기', title: '글자 크기', style: PILL },
-  icon: (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-      16 <ChevronDown size={10} />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup" style={{ minWidth: 60 }}>
-      {FONT_SIZES.map((size) => (
-        <button
-          key={size}
-          type="button"
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={() => {
-            const inner = safeSelected(getState)
-            const stripped = inner.replace(
-              /^<span style="font-size: \d+px">([\s\S]*)<\/span>$/,
-              '$1'
-            )
-            textApi?.replaceSelection(
-              `<span style="font-size: ${size}px">${stripped}</span>`
-            )
-            close()
-          }}
-        >
-          {size}
-        </button>
-      ))}
-    </div>
-  ),
-  execute: () => {},
-}
-
-const boldCommand: ICommand = {
-  name: 'bold',
-  keyCommand: 'bold',
-  buttonProps: { 'aria-label': '굵게', title: '굵게' },
-  icon: <b style={{ fontSize: 13, fontWeight: 700 }}>B</b>,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    const { bold, italic } = detectFormat(sel)
-    if (bold && italic) {
-      api.replaceSelection(`*${sel.slice(3, -3)}*`)
-    } else if (bold) {
-      api.replaceSelection(sel.slice(2, -2))
-    } else if (italic) {
-      api.replaceSelection(`***${sel.slice(1, -1)}***`)
-    } else {
-      api.replaceSelection(`**${sel || '굵게'}**`)
-    }
-  },
-}
-
-const italicCommand: ICommand = {
-  name: 'italic',
-  keyCommand: 'italic',
-  buttonProps: { 'aria-label': '기울임', title: '기울임' },
-  icon: <i style={{ fontSize: 13 }}>I</i>,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    const { bold, italic } = detectFormat(sel)
-    if (bold && italic) {
-      api.replaceSelection(`**${sel.slice(3, -3)}**`)
-    } else if (italic) {
-      api.replaceSelection(sel.slice(1, -1))
-    } else if (bold) {
-      api.replaceSelection(`***${sel.slice(2, -2)}***`)
-    } else {
-      api.replaceSelection(`*${sel || '기울임'}*`)
-    }
-  },
-}
-
-const underlineCommand: ICommand = {
-  name: 'underline',
-  keyCommand: 'underline',
-  buttonProps: { 'aria-label': '밑줄', title: '밑줄' },
-  icon: <Underline size={14} />,
-  execute: (state, api) => {
-    api.replaceSelection(toggleUnderline(state.selectedText))
-  },
-}
-
-// ~~markdown~~ 대신 <del> HTML을 사용 — markdown 취소선은 HTML 태그와 섞이면 파서가 깨짐
-const strikethroughCommand: ICommand = {
-  name: 'strikethrough',
-  keyCommand: 'strikethrough',
-  buttonProps: { 'aria-label': '취소선', title: '취소선' },
-  icon: <Strikethrough size={14} />,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    if (/^<del>[\s\S]*<\/del>$/.test(sel)) {
-      api.replaceSelection(sel.replace(/^<del>([\s\S]*)<\/del>$/, '$1'))
-    } else {
-      api.replaceSelection(`<del>${sel}</del>`)
-    }
-  },
-}
-
-const BG_PALETTE_COLORS = ['#ffffff', ...PALETTE_COLORS]
-const TEXT_PALETTE_COLORS = ['#ffffff', ...PALETTE_COLORS]
-
-const bgColorCommand: ICommand = {
-  name: 'bg-color',
-  keyCommand: 'group',
-  groupName: 'bg-color',
-  buttonProps: { 'aria-label': '배경색', title: '배경색' },
-  icon: (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-      <span
-        style={{
-          width: 16,
-          height: 16,
-          borderRadius: 3,
-          background: '#4285f4',
-          border: '1px solid rgba(0,0,0,0.12)',
-          display: 'inline-block',
-        }}
-      />
-      <ChevronDown size={10} />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div style={{ padding: 7 }}>
-      <button
-        type="button"
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => {
-          const selected = safeSelected(getState)
-          textApi?.replaceSelection(
-            selected.replace(/<mark[^>]*>([\s\S]*?)<\/mark>/g, '$1')
-          )
-          close()
-        }}
-        style={{
-          display: 'block',
-          width: '100%',
-          textAlign: 'center',
-          padding: '4px 8px',
-          marginBottom: 6,
-          fontSize: 12,
-          cursor: 'pointer',
-          border: '1px solid #e2e8f0',
-          borderRadius: 4,
-          background: 'transparent',
-          color: '#374151',
-        }}
-      >
-        배경색 제거
-      </button>
-      <div className="color-palette" style={{ padding: 0 }}>
-        {BG_PALETTE_COLORS.map((color) => (
-          <div
-            key={color}
-            className="color-swatch"
-            style={{
-              background: color,
-              border:
-                color === '#ffffff'
-                  ? '1px solid #d1d5db'
-                  : '1px solid rgba(0,0,0,0.12)',
-            }}
-            title={color}
-            onClick={() => {
-              const state = getState?.() as false | EditorFullState | undefined
-              if (!state) {
-                close?.()
-                return
-              }
-              const { text, selectedText, selection } = state
-              const before = text.substring(0, selection.start)
-              const after = text.substring(selection.end)
-              // 선택 영역이 이미 mark 태그 안에 있는 경우: 선택을 mark 전체로 확장 후 교체
-              const beforeMark = before.match(
-                /<mark style="background-color: [^"]*">$/
-              )
-              const afterMark = after.match(/^<\/mark>/)
-              if (beforeMark && afterMark) {
-                textApi?.setSelectionRange({
-                  start: selection.start - beforeMark[0].length,
-                  end: selection.end + afterMark[0].length,
-                })
-                textApi?.replaceSelection(
-                  `<mark style="background-color: ${color}">${selectedText}</mark>`
-                )
-              } else {
-                // 선택 안에 mark 태그가 포함된 경우: 모두 벗기고 새 색상 적용
-                const stripped = selectedText.replace(/<\/?mark[^>]*>/g, '')
-                textApi?.replaceSelection(
-                  `<mark style="background-color: ${color}">${stripped}</mark>`
-                )
-              }
-              close()
-            }}
-          />
-        ))}
-      </div>
-    </div>
-  ),
-  execute: () => {},
-}
-
-const TEXT_COLOR_SPAN_RE = /^<span style="color: [^"]*">$/
-
-const textColorCommand: ICommand = {
-  name: 'text-color',
-  keyCommand: 'group',
-  groupName: 'text-color',
-  buttonProps: { 'aria-label': '글자색', title: '글자색' },
-  icon: (
-    <span
-      style={{
-        display: 'inline-flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        gap: 2,
-        lineHeight: 1,
-      }}
-    >
-      <span style={{ fontWeight: 700, fontSize: 13 }}>A</span>
-      <span
-        style={{
-          width: 14,
-          height: 3,
-          background: '#e53e3e',
-          borderRadius: 1,
-          display: 'block',
-        }}
-      />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div className="color-palette">
-      {TEXT_PALETTE_COLORS.map((color) => (
-        <div
-          key={color}
-          className="color-swatch"
-          style={{
-            background: color,
-            border:
-              color === '#ffffff'
-                ? '1px solid #d1d5db'
-                : '1px solid rgba(0,0,0,0.12)',
-          }}
-          title={color}
-          onClick={() => {
-            const state = getState?.() as false | EditorFullState | undefined
-            if (!state) {
-              close?.()
-              return
-            }
-            const { text, selectedText, selection } = state
-            const before = text.substring(0, selection.start)
-            const after = text.substring(selection.end)
-            // 선택 영역이 color span 안에 있는 경우: span 전체로 확장 후 교체
-            const beforeSpan = before.match(/<span style="color: [^"]*">$/)
-            const afterSpan = after.match(/^<\/span>/)
-            if (
-              beforeSpan &&
-              TEXT_COLOR_SPAN_RE.test(beforeSpan[0]) &&
-              afterSpan
-            ) {
-              textApi?.setSelectionRange({
-                start: selection.start - beforeSpan[0].length,
-                end: selection.end + afterSpan[0].length,
-              })
-              textApi?.replaceSelection(
-                `<span style="color: ${color}">${selectedText}</span>`
-              )
-            } else {
-              // 선택 안에 color span이 있는 경우: 모두 벗기고 새 색상 적용
-              const stripped = selectedText.replace(
-                /<span style="color: [^"]*">([\s\S]*?)<\/span>/g,
-                '$1'
-              )
-              textApi?.replaceSelection(
-                `<span style="color: ${color}">${stripped}</span>`
-              )
-            }
-            close()
-          }}
-        />
-      ))}
-    </div>
-  ),
-  execute: () => {},
-}
-
-const alignLeftCommand: ICommand = {
-  name: 'align-left',
-  keyCommand: 'align-left',
-  buttonProps: { 'aria-label': '왼쪽 정렬', title: '왼쪽 정렬' },
-  icon: <AlignLeft size={14} />,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    if (/^<span style="display: block; text-align: left">/.test(sel)) {
-      api.replaceSelection(stripAlignSpan(sel))
-    } else {
-      api.replaceSelection(
-        `<span style="display: block; text-align: left">${stripAlignSpan(sel)}</span>`
-      )
-    }
-  },
-}
-
-const alignCenterCommand: ICommand = {
-  name: 'align-center',
-  keyCommand: 'align-center',
-  buttonProps: { 'aria-label': '가운데 정렬', title: '가운데 정렬' },
-  icon: <AlignCenter size={14} />,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    if (/^<span style="display: block; text-align: center">/.test(sel)) {
-      api.replaceSelection(stripAlignSpan(sel))
-    } else {
-      api.replaceSelection(
-        `<span style="display: block; text-align: center">${stripAlignSpan(sel)}</span>`
-      )
-    }
-  },
-}
-
-const alignRightCommand: ICommand = {
-  name: 'align-right',
-  keyCommand: 'align-right',
-  buttonProps: { 'aria-label': '오른쪽 정렬', title: '오른쪽 정렬' },
-  icon: <AlignRight size={14} />,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    if (/^<span style="display: block; text-align: right">/.test(sel)) {
-      api.replaceSelection(stripAlignSpan(sel))
-    } else {
-      api.replaceSelection(
-        `<span style="display: block; text-align: right">${stripAlignSpan(sel)}</span>`
-      )
-    }
-  },
-}
-
-const alignJustifyCommand: ICommand = {
-  name: 'align-justify',
-  keyCommand: 'align-justify',
-  buttonProps: { 'aria-label': '양쪽 정렬', title: '양쪽 정렬' },
-  icon: <AlignJustify size={14} />,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    if (/^<span style="display: block; text-align: justify">/.test(sel)) {
-      api.replaceSelection(stripAlignSpan(sel))
-    } else {
-      api.replaceSelection(
-        `<span style="display: block; text-align: justify">${stripAlignSpan(sel)}</span>`
-      )
-    }
-  },
-}
-
-const listDropdownCmd: ICommand = {
-  name: 'list-style',
-  keyCommand: 'group',
-  groupName: 'list-style',
-  buttonProps: { 'aria-label': '목록', title: '목록' },
-  icon: (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
-      <List size={13} />
-      <ChevronDown size={10} />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup">
-      <button
-        type="button"
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => {
-          const text = safeSelected(getState)
-          const lines = text
-            ? text
-                .split('\n')
-                .map((l) => `- ${l}`)
-                .join('\n')
-            : '- '
-          textApi?.replaceSelection(lines)
-          close()
-        }}
-      >
-        글머리 목록
-      </button>
-      <button
-        type="button"
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => {
-          const text = safeSelected(getState)
-          const lines = text
-            ? text
-                .split('\n')
-                .map((l, i) => `${i + 1}. ${l}`)
-                .join('\n')
-            : '1. '
-          textApi?.replaceSelection(lines)
-          close()
-        }}
-      >
-        번호 목록
-      </button>
-      <button
-        type="button"
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => {
-          const text = safeSelected(getState)
-          const lines = text
-            ? text
-                .split('\n')
-                .map((l) => `- [ ] ${l}`)
-                .join('\n')
-            : '- [ ] '
-          textApi?.replaceSelection(lines)
-          close()
-        }}
-      >
-        체크 목록
-      </button>
-    </div>
-  ),
-  execute: () => {},
-}
-
-const lineHeightCmd: ICommand = {
-  name: 'line-height',
-  keyCommand: 'group',
-  groupName: 'line-height',
-  buttonProps: { 'aria-label': '줄 간격', title: '줄 간격' },
-  icon: <ArrowUpDown size={14} />,
-  children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup" style={{ minWidth: 80 }}>
-      {['1', '1.5', '2', '2.5', '3'].map((h) => (
-        <button
-          key={h}
-          type="button"
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={() => {
-            const text = safeSelected(getState)
-            const stripped = stripLineHeightSpan(text)
-            textApi?.replaceSelection(
-              `<span style="display: block; line-height: ${h}">${stripped}</span>`
-            )
-            close()
-          }}
-        >
-          {h}배
-        </button>
-      ))}
-    </div>
-  ),
-  execute: () => {},
-}
-
-const outdentCmd: ICommand = {
-  name: 'outdent',
-  keyCommand: 'outdent',
-  buttonProps: { 'aria-label': '내어쓰기', title: '내어쓰기' },
-  icon: <IndentDecrease size={14} />,
-  execute: (state, api) => {
-    const lines = state.selectedText
-      ? state.selectedText
-          .split('\n')
-          .map((l) => (l.startsWith('  ') ? l.slice(2) : l))
-          .join('\n')
-      : ''
-    api.replaceSelection(lines)
-  },
-}
-
-const indentCmd: ICommand = {
-  name: 'indent',
-  keyCommand: 'indent',
-  buttonProps: { 'aria-label': '들여쓰기', title: '들여쓰기' },
-  icon: <IndentIncrease size={14} />,
-  execute: (state, api) => {
-    const lines = state.selectedText
-      ? state.selectedText
-          .split('\n')
-          .map((l) => `  ${l}`)
-          .join('\n')
-      : '  '
-    api.replaceSelection(lines)
-  },
-}
-
-const clearFormatCmd: ICommand = {
-  name: 'clear-format',
-  keyCommand: 'clear-format',
-  buttonProps: { 'aria-label': '서식 제거', title: '서식 제거' },
-  icon: <RemoveFormatting size={14} />,
-  execute: (state, api) => {
-    if (!state.selectedText) return
-    const cleaned = state.selectedText
-      .replace(/\*\*(.*?)\*\*/gs, '$1')
-      .replace(/\*(.*?)\*/gs, '$1')
-      .replace(/<[^>]+>/gs, '')
-    api.replaceSelection(cleaned)
-  },
-}
-
-const boldCommand: ICommand = {
-  ...mdCommands.bold,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    if (sel.startsWith('***') && sel.endsWith('***') && sel.length >= 6) {
-      api.replaceSelection('*' + sel.slice(3, -3) + '*')
-    } else if (
-      sel.startsWith('**') &&
-      !sel.startsWith('***') &&
-      sel.endsWith('**') &&
-      !sel.endsWith('***') &&
-      sel.length >= 4
-    ) {
-      api.replaceSelection(sel.slice(2, -2))
-    } else {
-      api.replaceSelection(`**${sel}**`)
-    }
-  },
-}
-
-const italicCommand: ICommand = {
-  ...mdCommands.italic,
-  execute: (state, api) => {
-    const sel = state.selectedText
-    if (sel.startsWith('***') && sel.endsWith('***') && sel.length >= 6) {
-      api.replaceSelection('**' + sel.slice(3, -3) + '**')
-    } else if (
-      sel.startsWith('*') &&
-      !sel.startsWith('**') &&
-      sel.endsWith('*') &&
-      !sel.endsWith('**') &&
-      sel.length >= 2
-    ) {
-      api.replaceSelection(sel.slice(1, -1))
-    } else {
-      api.replaceSelection(`*${sel}*`)
-    }
-  },
-}
-
-const UNDO_LIMIT = 50
 
 export function MarkdownEditor({
   value,
   onChange,
-  onImageUpload,
   error,
+  actions,
+  wrapperClassName,
 }: MarkdownEditorProps) {
-  const [isUploading, setIsUploading] = useState(false)
-  const [imageError, setImageError] = useState<string | null>(null)
-  const [undoStack, setUndoStack] = useState<string[]>([])
-  const [redoStack, setRedoStack] = useState<string[]>([])
-  const valueRef = useRef(value)
-  const objectUrlsRef = useRef<Set<string>>(new Set())
+  const [selectedFontLabel, setSelectedFontLabel] = useState('기본서체')
+  const [selectedFontSize, setSelectedFontSize] = useState(16)
+  const [isDragOver, setIsDragOver] = useState(false)
+  const dragCounterRef = useRef(0)
+  const editorWrapRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    valueRef.current = value
-  }, [value])
+  const {
+    valueRef,
+    setUndoStack,
+    setRedoStack,
+    handleChange,
+    undoCommand,
+    redoCommand,
+  } = useMarkdownHistory(value, onChange)
 
+  const { isUploading, imageError, uploadImageFile, imageCommand } =
+    useImageUpload(valueRef, onChange)
+
+  // Tab / Enter 인터셉트: 들여쓰기된 목록 항목의 번호·연속성 처리
+  // wrap(부모)에 capture 등록 → 라이브러리 textarea 리스너보다 반드시 먼저 실행됨
   useEffect(() => {
-    const urls = objectUrlsRef.current
-    return () => {
-      urls.forEach((url) => URL.revokeObjectURL(url))
+    const wrap = editorWrapRef.current
+    if (!wrap) return
+
+    const applyText = (
+      ta: HTMLTextAreaElement,
+      newText: string,
+      cursor: number
+    ) => {
+      const nativeSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        'value'
+      )?.set
+      if (!nativeSetter) return
+      nativeSetter.call(ta, newText)
+      ta.dispatchEvent(new Event('input', { bubbles: true }))
+      ta.selectionStart = ta.selectionEnd = cursor
     }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!(e.target instanceof HTMLTextAreaElement)) return
+      const ta = e.target
+      const text = ta.value
+      const cursor = ta.selectionStart
+      const lineStart = text.lastIndexOf('\n', cursor - 1) + 1
+      const lineEndRaw = text.indexOf('\n', cursor)
+      const lineEnd = lineEndRaw === -1 ? text.length : lineEndRaw
+      const line = text.slice(lineStart, lineEnd)
+
+      // ── Tab / Shift+Tab: 번호 목록 들여쓰기 + 번호 재정규화 ──
+      if (e.key === 'Tab') {
+        const match = line.match(/^(\s*)(\d+)\. (.*)/)
+        if (!match) return
+
+        e.preventDefault()
+        e.stopPropagation()
+
+        const currentIndent = match[1]
+        const content = match[3]
+        const lines = text.split('\n')
+        const lineIndex = (text.slice(0, lineStart).match(/\n/g) ?? []).length
+
+        let newLineStr: string
+        let newLines: string[]
+
+        if (!e.shiftKey) {
+          // Tab: 3칸 들여쓰기 + 번호 1로 초기화
+          const newIndent = currentIndent + '   '
+          newLineStr = `${newIndent}1. ${content}`
+          newLines = renumberFrom(
+            [
+              ...lines.slice(0, lineIndex),
+              newLineStr,
+              ...lines.slice(lineIndex + 1),
+            ],
+            lineIndex + 1,
+            currentIndent
+          )
+        } else {
+          // Shift+Tab: 3칸 내어쓰기 + 부모 레벨 번호 계산
+          if (currentIndent.length < 3) return
+          const newIndent = currentIndent.slice(3)
+          const num = computeNextNumber(lines, lineIndex, newIndent)
+          newLineStr = `${newIndent}${num}. ${content}`
+          newLines = renumberFrom(
+            [
+              ...lines.slice(0, lineIndex),
+              newLineStr,
+              ...lines.slice(lineIndex + 1),
+            ],
+            lineIndex + 1,
+            newIndent
+          )
+        }
+
+        const newText = newLines.join('\n')
+        const newLineStart =
+          lineIndex === 0
+            ? 0
+            : newLines.slice(0, lineIndex).join('\n').length + 1
+        applyText(ta, newText, newLineStart + newLineStr.length)
+        return
+      }
+
+      // ── Enter: 들여쓰기된 목록 항목 연속 생성 ──
+      // 라이브러리는 indent 있는 항목을 인식 못함 → 여기서 처리
+      // isComposing=true: 한글 IME 조합 중 Enter → 글자 확정만 하고 줄바꿈은 다음 이벤트에서 처리
+      if (
+        e.key === 'Enter' &&
+        !e.shiftKey &&
+        !e.isComposing &&
+        ta.selectionStart === ta.selectionEnd
+      ) {
+        // 들여쓰기된 번호 목록 (비어있지 않은 항목)
+        const orderedMatch = line.match(/^( +)(\d+)\. (.+)/)
+        if (orderedMatch) {
+          e.preventDefault()
+          e.stopPropagation()
+          const [, indent, numStr] = orderedMatch
+          const insertion = `\n${indent}${parseInt(numStr, 10) + 1}. `
+          const newText = text.slice(0, cursor) + insertion + text.slice(cursor)
+          applyText(ta, newText, cursor + insertion.length)
+          return
+        }
+
+        // 들여쓰기된 번호 목록 (빈 항목 → 상위 레벨로 복귀)
+        const orderedEmptyMatch = line.match(/^( +)(\d+)\. $/)
+        if (orderedEmptyMatch) {
+          e.preventDefault()
+          e.stopPropagation()
+          const [, indent, numStr] = orderedEmptyMatch
+          const nextItem = `${indent}${parseInt(numStr, 10) + 1}. `
+          const newText =
+            text.slice(0, lineStart) + nextItem + text.slice(lineEnd)
+          applyText(ta, newText, lineStart + nextItem.length)
+          return
+        }
+
+        // 들여쓰기된 글머리 목록 (비어있지 않은 항목)
+        const bulletMatch = line.match(/^( +)([-*]) (.+)/)
+        if (bulletMatch) {
+          e.preventDefault()
+          e.stopPropagation()
+          const [, indent, bullet] = bulletMatch
+          const insertion = `\n${indent}${bullet} `
+          const newText = text.slice(0, cursor) + insertion + text.slice(cursor)
+          applyText(ta, newText, cursor + insertion.length)
+          return
+        }
+
+        // 들여쓰기된 글머리 목록 (빈 항목)
+        const bulletEmptyMatch = line.match(/^( +)([-*]) $/)
+        if (bulletEmptyMatch) {
+          e.preventDefault()
+          e.stopPropagation()
+          const [, indent, bullet] = bulletEmptyMatch
+
+          // 이전 줄이 같은 들여쓰기만 있는 줄인지 확인 → 3번째 엔터 감지
+          const prevLineEnd = lineStart - 1
+          const prevLineStart =
+            lineStart > 0 ? text.lastIndexOf('\n', prevLineEnd - 1) + 1 : 0
+          const prevLine =
+            lineStart > 0 ? text.slice(prevLineStart, prevLineEnd) : ''
+
+          if (prevLine === indent) {
+            // 3번째 엔터: 이전 '    ' 줄은 유지, 현재 줄을 부모 레벨 bullet으로 교체
+            const lines = text.split('\n')
+            const lineIndex = (text.slice(0, lineStart).match(/\n/g) ?? [])
+              .length
+            let parentIndent = ''
+            for (let i = lineIndex - 1; i >= 0; i--) {
+              const prevBulletMatch = lines[i].match(/^(\s*)([-*]) /)
+              if (
+                prevBulletMatch &&
+                prevBulletMatch[1].length < indent.length
+              ) {
+                parentIndent = prevBulletMatch[1]
+                break
+              }
+            }
+            const newLine = `${parentIndent}${bullet} `
+            const newText =
+              text.slice(0, lineStart) + newLine + text.slice(lineEnd)
+            applyText(ta, newText, lineStart + newLine.length)
+          } else {
+            // 2번째 엔터: 현재 줄에서 '-' 제거(들여쓰기 유지), 새 하위 bullet 줄 추가
+            const newText =
+              text.slice(0, lineStart) +
+              indent +
+              `\n${indent}${bullet} ` +
+              text.slice(lineEnd)
+            applyText(
+              ta,
+              newText,
+              lineStart + indent.length + 1 + indent.length + bullet.length + 1
+            )
+          }
+          return
+        }
+
+        // 인용문 (빈 항목, '> ' 공백 있음)
+        const blockquoteEmptyWithSpaceMatch = line.match(/^(>+) $/)
+        if (blockquoteEmptyWithSpaceMatch) {
+          e.preventDefault()
+          e.stopPropagation()
+          const [, markers] = blockquoteEmptyWithSpaceMatch
+          // 바로 위 줄이 '>' 구분선이면 → 구분선 + 현재 줄 제거 (인용문 해제)
+          const prevLineEnd = lineStart - 1 // lineStart 앞의 '\n'
+          const prevLineStart = text.lastIndexOf('\n', prevLineEnd - 1) + 1
+          const prevLine = text.slice(prevLineStart, prevLineEnd)
+          if (prevLine === markers) {
+            const textBefore = text.slice(0, prevLineStart)
+            const textAfter = text.slice(lineEnd)
+            // 인용문 뒤에 반드시 빈 줄이 있어야 CommonMark lazy continuation 방지
+            const needsExtraNewline = !textAfter.startsWith('\n')
+            const newText =
+              textBefore + (needsExtraNewline ? '\n' : '') + textAfter
+            const cursorPos = prevLineStart + (needsExtraNewline ? 1 : 0)
+            applyText(ta, newText, cursorPos)
+          } else {
+            // 위 줄이 구분선이 아니면 → '>' + '\n' + '> ' 삽입 (문단 구분)
+            const newText =
+              text.slice(0, lineStart) +
+              markers +
+              '\n' +
+              markers +
+              ' ' +
+              text.slice(lineEnd)
+            applyText(ta, newText, lineStart + markers.length * 2 + 2)
+          }
+          return
+        }
+
+        // 인용문 (빈 항목, '>' 공백 없음 → 인용문 해제)
+        const blockquoteEmptyMatch = line.match(/^(>+)$/)
+        if (blockquoteEmptyMatch) {
+          e.preventDefault()
+          e.stopPropagation()
+          const newText = text.slice(0, lineStart) + text.slice(lineEnd)
+          applyText(ta, newText, lineStart)
+          return
+        }
+
+        // 인용문 (공백 없이 '>' 바로 텍스트 → 라이브러리 자동 계속 방지, 일반 줄바꿈)
+        const blockquoteNoSpaceMatch = line.match(/^>+[^ \n]/)
+        if (blockquoteNoSpaceMatch) {
+          e.preventDefault()
+          e.stopPropagation()
+          const insertion = '\n'
+          const newText = text.slice(0, cursor) + insertion + text.slice(cursor)
+          applyText(ta, newText, cursor + insertion.length)
+          return
+        }
+
+        // 인용문 (내용 있는 항목 → 다음 줄도 인용문 유지, 공백 필수 '> text')
+        const blockquoteMatch = line.match(/^(>+) /)
+        if (blockquoteMatch) {
+          e.preventDefault()
+          e.stopPropagation()
+          const [, markers] = blockquoteMatch
+          const insertion = `\n${markers} `
+          const newText = text.slice(0, cursor) + insertion + text.slice(cursor)
+          applyText(ta, newText, cursor + insertion.length)
+          return
+        }
+      }
+    }
+
+    wrap.addEventListener('keydown', onKeyDown, true)
+    return () => wrap.removeEventListener('keydown', onKeyDown, true)
   }, [])
 
-  const handleChange = (newValue: string) => {
-    setUndoStack((prev) => {
-      const next = [...prev, valueRef.current]
-      return next.length > UNDO_LIMIT ? next.slice(-UNDO_LIMIT) : next
-    })
-    setRedoStack([])
-    onChange(newValue)
-  }
-
-  const handleUndo = useCallback(() => {
-    if (undoStack.length === 0) return
-    const prev = undoStack[undoStack.length - 1]
-    setRedoStack((r) => [...r, valueRef.current])
-    setUndoStack((u) => u.slice(0, -1))
-    onChange(prev)
-  }, [undoStack, onChange])
-
-  const handleRedo = useCallback(() => {
-    if (redoStack.length === 0) return
-    const next = redoStack[redoStack.length - 1]
-    setUndoStack((u) => [...u, valueRef.current])
-    setRedoStack((r) => r.slice(0, -1))
-    onChange(next)
-  }, [redoStack, onChange])
-
-  const undoCommand = useMemo<ICommand>(
-    () => ({
-      name: 'undo',
-      keyCommand: 'undo',
-      buttonProps: {
-        'aria-label': '실행 취소',
-        title: '실행 취소',
-        'data-inactive': undoStack.length === 0 ? 'true' : undefined,
-      } as React.ButtonHTMLAttributes<HTMLButtonElement>,
-      icon: <Undo2 size={14} />,
-      execute: handleUndo,
-    }),
-    [undoStack.length, handleUndo]
+  const handleDrop = useCallback(
+    async (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      dragCounterRef.current = 0
+      setIsDragOver(false)
+      const files = Array.from(e.dataTransfer.files)
+      const imageFiles = files.filter((f) =>
+        ACCEPTED_IMAGE_TYPES.includes(f.type)
+      )
+      if (imageFiles.length === 0) {
+        // 이미지가 아닌 파일 → uploadImageFile 내부의 타입 체크에서 에러 메시지 설정
+        if (files.length > 0) await uploadImageFile(files[0], () => {})
+        return
+      }
+      for (const file of imageFiles) {
+        await uploadImageFile(file, (md) => {
+          const current = valueRef.current
+          const sep = current.length > 0 && !current.endsWith('\n') ? '\n' : ''
+          setUndoStack((prev) => {
+            const next = [...prev, current]
+            return next.length > UNDO_LIMIT ? next.slice(-UNDO_LIMIT) : next
+          })
+          setRedoStack([])
+          onChange(current + sep + md)
+        })
+      }
+    },
+    [uploadImageFile, onChange, valueRef, setUndoStack, setRedoStack]
   )
 
-  const redoCommand = useMemo<ICommand>(
+  const fontFamilyCommand = useMemo<ICommand>(
     () => ({
-      name: 'redo',
-      keyCommand: 'redo',
+      name: 'font-family',
+      keyCommand: 'group',
+      groupName: 'font-family',
       buttonProps: {
-        'aria-label': '다시 실행',
-        title: '다시 실행',
-        'data-inactive': redoStack.length === 0 ? 'true' : undefined,
-      } as React.ButtonHTMLAttributes<HTMLButtonElement>,
-      icon: <Redo2 size={14} />,
-      execute: handleRedo,
-    }),
-    [redoStack.length, handleRedo]
-  )
-
-  const imageCommand: ICommand = useMemo(
-    () => ({
-      name: 'image',
-      keyCommand: 'image',
-      buttonProps: { 'aria-label': '이미지 업로드', title: '이미지 업로드' },
-      icon: (
-        <svg width="14" height="14" viewBox="0 0 20 20">
-          <path
-            fill="currentColor"
-            d="M15 9c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm4-7H1c-.55 0-1 .45-1 1v14c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 13l-6-5-2 2-4-5-4 6V4h16v11z"
-          />
-        </svg>
-      ),
-      execute: (_state, api) => {
-        if (!onImageUpload) return
-        const input = document.createElement('input')
-        input.type = 'file'
-        input.accept = ACCEPTED_IMAGE_TYPES.join(',')
-        input.onchange = async () => {
-          const file = input.files?.[0]
-          if (!file) return
-          if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
-            setImageError('JPG, PNG, GIF, WEBP 형식만 업로드할 수 있습니다.')
-            return
-          }
-          setImageError(null)
-          setIsUploading(true)
-          const objectUrl = URL.createObjectURL(file)
-          objectUrlsRef.current.add(objectUrl)
-          api.replaceSelection(`![${file.name}](${objectUrl})`)
-          try {
-            const serverUrl = await onImageUpload(file)
-            handleChange(valueRef.current.replaceAll(objectUrl, serverUrl))
-            URL.revokeObjectURL(objectUrl)
-            objectUrlsRef.current.delete(objectUrl)
-          } catch {
-            URL.revokeObjectURL(objectUrl)
-            objectUrlsRef.current.delete(objectUrl)
-            setImageError('이미지 업로드에 실패했습니다. 다시 시도해 주세요.')
-          } finally {
-            setIsUploading(false)
-          }
-        }
-        input.click()
+        'aria-label': '글꼴',
+        title: '글꼴',
+        style: PILL,
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
       },
+      icon: (
+        <span className="toolbar-pill-icon">
+          {selectedFontLabel} <ChevronDown size={10} />
+        </span>
+      ),
+      children: ({ close, getState, textApi }) => (
+        <div className="toolbar-popup" onMouseDown={(e) => e.preventDefault()}>
+          {FONT_FAMILIES.map(({ label, value }) => (
+            <button
+              key={value}
+              type="button"
+              style={{ fontFamily: value === 'inherit' ? undefined : value }}
+              onClick={() => {
+                applyInlineFromDropdown(getState, textApi, (t) =>
+                  wrapWithStyle(t, 'font-family', value)
+                )
+                close()
+                setTimeout(() => setSelectedFontLabel(label), 0)
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      ),
+      execute: () => {},
     }),
-    [onImageUpload, handleChange]
+    [selectedFontLabel]
+  )
+
+  const fontSizeCommand = useMemo<ICommand>(
+    () => ({
+      name: 'font-size',
+      keyCommand: 'group',
+      groupName: 'font-size',
+      buttonProps: {
+        'aria-label': '글자 크기',
+        title: '글자 크기',
+        style: PILL,
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
+      },
+      icon: (
+        <span className="toolbar-pill-icon">
+          {selectedFontSize} <ChevronDown size={10} />
+        </span>
+      ),
+      children: ({ close, getState, textApi }) => (
+        <div
+          className="toolbar-popup toolbar-popup--font-size"
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          {FONT_SIZES.map((size) => (
+            <button
+              key={size}
+              type="button"
+              onClick={() => {
+                applyInlineFromDropdown(getState, textApi, (t) =>
+                  wrapWithStyle(t, 'font-size', `${size}px`)
+                )
+                close()
+                setTimeout(() => setSelectedFontSize(size), 0)
+              }}
+            >
+              {size}
+            </button>
+          ))}
+        </div>
+      ),
+      execute: () => {},
+    }),
+    [selectedFontSize]
   )
 
   const editorCommands: ICommand[] = useMemo(
@@ -870,10 +460,13 @@ export function MarkdownEditor({
       bgColorCommand,
       textColorCommand,
       mdCommands.divider,
-      mdCommands.link,
+      {
+        ...mdCommands.link,
+        buttonProps: { ...mdCommands.link.buttonProps, ...NO_BLUR_PROPS },
+      },
       imageCommand,
     ],
-    [imageCommand, undoCommand, redoCommand]
+    [imageCommand, undoCommand, redoCommand, fontFamilyCommand, fontSizeCommand]
   )
 
   const editorExtraCommands: ICommand[] = useMemo(
@@ -893,155 +486,46 @@ export function MarkdownEditor({
   )
 
   return (
-    <div className="bg-bg-base rounded-[20px] border border-[#cdcdcd]">
-      <div data-color-mode="light" className="post-editor-wrap">
+    <div
+      className={
+        wrapperClassName != null
+          ? `${wrapperClassName}${isDragOver ? 'border-primary border-2' : ''}`
+          : `bg-bg-base relative rounded-[20px] border ${isDragOver ? 'border-primary border-2' : 'border-[#cdcdcd]'}`
+      }
+      onDrop={handleDrop}
+      onDragOver={(e) => e.preventDefault()}
+      onDragEnter={(e) => {
+        e.preventDefault()
+        dragCounterRef.current++
+        setIsDragOver(true)
+      }}
+      onDragLeave={() => {
+        dragCounterRef.current--
+        if (dragCounterRef.current === 0) setIsDragOver(false)
+      }}
+    >
+      {isDragOver && (
+        <div className="border-primary bg-primary/5 pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-[20px] border-2 border-dashed">
+          <p className="text-primary font-medium">이미지를 여기에 놓으세요</p>
+        </div>
+      )}
+      <div
+        data-color-mode="light"
+        className="post-editor-wrap"
+        ref={editorWrapRef}
+      >
         <MDEditor
           value={value}
           onChange={(v) => handleChange(v ?? '')}
           preview="live"
           commands={editorCommands}
           extraCommands={editorExtraCommands}
-          textareaProps={{
-            onKeyDown: (e) => {
-              if (e.shiftKey && e.key === 'Enter') {
-                e.preventDefault()
-                const textarea = e.currentTarget
-                const start = textarea.selectionStart
-                const end = textarea.selectionEnd
-                const insert = '<br>\n'
-                const current = textarea.value
-                const next =
-                  current.substring(0, start) + insert + current.substring(end)
-                handleChange(next)
-                requestAnimationFrame(() => {
-                  textarea.selectionStart = start + insert.length
-                  textarea.selectionEnd = start + insert.length
-                })
-              }
-              if (!e.shiftKey && e.key === 'Enter') {
-                const textarea = e.currentTarget
-                const start = textarea.selectionStart
-                const end = textarea.selectionEnd
-                const text = textarea.value
-                const lineStart = text.lastIndexOf('\n', start - 1) + 1
-                const lineNlPos = text.indexOf('\n', lineStart)
-                const lineEnd = lineNlPos === -1 ? text.length : lineNlPos
-                const currentLine = text.substring(lineStart, lineEnd)
-                if (/^>/.test(currentLine)) {
-                  e.preventDefault()
-                  if (!/^>\s*$/.test(currentLine)) {
-                    const insert = '\n> '
-                    const next =
-                      text.substring(0, start) + insert + text.substring(end)
-                    handleChange(next)
-                    requestAnimationFrame(() => {
-                      textarea.selectionStart = start + insert.length
-                      textarea.selectionEnd = start + insert.length
-                    })
-                  } else {
-                    const prevLineEnd = lineStart - 1
-                    const isPrevEmptyBlockquote =
-                      prevLineEnd >= 0 &&
-                      /^>\s*$/.test(
-                        text.substring(
-                          text.lastIndexOf('\n', prevLineEnd - 1) + 1,
-                          prevLineEnd
-                        )
-                      )
-                    if (isPrevEmptyBlockquote) {
-                      const next =
-                        text.substring(0, lineStart) +
-                        text.substring(lineStart + currentLine.length)
-                      handleChange(next)
-                      requestAnimationFrame(() => {
-                        textarea.selectionStart = lineStart
-                        textarea.selectionEnd = lineStart
-                      })
-                    } else {
-                      const insert = '\n> '
-                      const next =
-                        text.substring(0, start) + insert + text.substring(end)
-                      handleChange(next)
-                      requestAnimationFrame(() => {
-                        textarea.selectionStart = start + insert.length
-                        textarea.selectionEnd = start + insert.length
-                      })
-                    }
-                  }
-                } else if (/^\s+[-*]\s*/.test(currentLine)) {
-                  e.preventDefault()
-                  const listMatch = currentLine.match(/^(\s+)([-*])\s*/)
-                  if (listMatch) {
-                    const indent = listMatch[1]
-                    const marker = listMatch[2]
-                    const prefix = `${indent}${marker} `
-                    const isEmptyItem = /^\s+[-*]\s*$/.test(currentLine)
-                    if (!isEmptyItem) {
-                      const insert = `\n${prefix}`
-                      const next =
-                        text.substring(0, start) + insert + text.substring(end)
-                      handleChange(next)
-                      requestAnimationFrame(() => {
-                        textarea.selectionStart = start + insert.length
-                        textarea.selectionEnd = start + insert.length
-                      })
-                    } else {
-                      const prevLineEnd = lineStart - 1
-                      const isPrevEmptyItem =
-                        prevLineEnd >= 0 &&
-                        /^\s+[-*]\s*$/.test(
-                          text.substring(
-                            text.lastIndexOf('\n', prevLineEnd - 1) + 1,
-                            prevLineEnd
-                          )
-                        )
-                      if (isPrevEmptyItem) {
-                        const newIndent = indent.slice(2)
-                        const replacement = newIndent
-                          ? `${newIndent}${marker} `
-                          : `${marker} `
-                        const next =
-                          text.substring(0, lineStart) +
-                          replacement +
-                          text.substring(lineStart + currentLine.length)
-                        handleChange(next)
-                        requestAnimationFrame(() => {
-                          textarea.selectionStart =
-                            lineStart + replacement.length
-                          textarea.selectionEnd = lineStart + replacement.length
-                        })
-                      } else {
-                        const insert = `\n${prefix}`
-                        const next =
-                          text.substring(0, start) +
-                          insert +
-                          text.substring(end)
-                        handleChange(next)
-                        requestAnimationFrame(() => {
-                          textarea.selectionStart = start + insert.length
-                          textarea.selectionEnd = start + insert.length
-                        })
-                      }
-                    }
-                  }
-                }
-              }
-              if (e.key === 'Tab') {
-                e.preventDefault()
-                const textarea = e.currentTarget
-                const start = textarea.selectionStart
-                const end = textarea.selectionEnd
-                const insert = '  '
-                const current = textarea.value
-                const next =
-                  current.substring(0, start) + insert + current.substring(end)
-                handleChange(next)
-                requestAnimationFrame(() => {
-                  textarea.selectionStart = start + insert.length
-                  textarea.selectionEnd = start + insert.length
-                })
-              }
-            },
+          previewOptions={{
+            remarkRehypeOptions: { allowDangerousHtml: true },
+            rehypePlugins: [
+              [rehypeRaw],
+              [rehypeSanitize, editorSanitizeSchema],
+            ],
           }}
         />
       </div>
@@ -1060,6 +544,7 @@ export function MarkdownEditor({
           {error}
         </p>
       )}
+      {actions && <div className="flex justify-end px-4 pb-3">{actions}</div>}
     </div>
   )
 }

--- a/src/components/community/MarkdownEditor/index.ts
+++ b/src/components/community/MarkdownEditor/index.ts
@@ -1,2 +1,1 @@
-export { MarkdownEditor } from './MarkdownEditor'
-export type { MarkdownEditorProps } from './MarkdownEditor'
+export * from './MarkdownEditor'

--- a/src/components/community/MarkdownEditor/markdownEditorCommands.ts
+++ b/src/components/community/MarkdownEditor/markdownEditorCommands.ts
@@ -1,0 +1,553 @@
+import React from 'react'
+import { commands as mdCommands, type ICommand } from '@uiw/react-md-editor'
+import {
+  Underline,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  AlignJustify,
+  List,
+  ChevronDown,
+  ArrowUpDown,
+  RemoveFormatting,
+  IndentIncrease,
+  IndentDecrease,
+} from 'lucide-react'
+import {
+  BG_PALETTE_COLORS,
+  TEXT_PALETTE_COLORS,
+} from './markdownEditorConstants'
+import {
+  applyInline,
+  applyBlock,
+  applyInlineFromDropdown,
+  applyBlockFromDropdown,
+  insertListPrefix,
+  wrapWithStyle,
+  stripStyleProp,
+  wrapDivWithStyle,
+  getEnclosingURange,
+  getEnclosingMarkRange,
+  safeGetState,
+  replaceInText,
+  type EditorState,
+} from './markdownEditorUtils'
+
+/**
+ * HTML 인식 Bold 토글.
+ * react-md-editor 기본 execute는 \S 기준 단어 선택으로 HTML 속성 안까지 선택될 수 있음.
+ * applyInline 사용으로 <> 경계 인식 + isCursorInsideTag 체크.
+ *
+ * 토글 규칙:
+ *   **text**   → text       (bold 제거)
+ *   *text*     → ***text*** (이미 italic → bold+italic 추가)
+ *   text       → **text**   (bold 추가)
+ */
+export const boldCommand: ICommand = {
+  ...mdCommands.bold,
+  execute: (state: EditorState, api) =>
+    applyInline(state, api, (t) => {
+      if (t.startsWith('**') && t.endsWith('**') && t.length >= 4) {
+        return t.slice(2, -2)
+      }
+      return `**${t}**`
+    }),
+}
+
+/**
+ * HTML 인식 Italic 토글.
+ * Bold 마커 **를 italic 마커 *로 잘못 인식하는 버그 수정.
+ *
+ * 토글 규칙:
+ *   ***text*** → **text**   (bold+italic → bold만 남김)
+ *   *text*     → text       (italic 제거, **로 시작하지 않을 때만)
+ *   **text**   → ***text*** (이미 bold → bold+italic 추가)
+ *   text       → *text*     (italic 추가)
+ */
+export const italicCommand: ICommand = {
+  ...mdCommands.italic,
+  execute: (state: EditorState, api) =>
+    applyInline(state, api, (t) => {
+      if (t.startsWith('***') && t.endsWith('***') && t.length >= 6) {
+        return `**${t.slice(3, -3)}**`
+      }
+      if (t.startsWith('**') && t.endsWith('**') && t.length >= 4) {
+        return `***${t.slice(2, -2)}***`
+      }
+      if (t.startsWith('*') && t.endsWith('*') && t.length >= 2) {
+        return t.slice(1, -1)
+      }
+      return `*${t}*`
+    }),
+}
+
+/**
+ * HTML 인식 Strikethrough 토글.
+ * applyInline 사용으로 HTML 속성 안까지 선택되는 문제 방지.
+ */
+export const strikethroughCommand: ICommand = {
+  ...mdCommands.strikethrough,
+  execute: (state: EditorState, api) =>
+    applyInline(state, api, (t) => {
+      if (t.startsWith('~~') && t.endsWith('~~') && t.length >= 4) {
+        return t.slice(2, -2)
+      }
+      return `~~${t}~~`
+    }),
+}
+
+/** 밑줄 토글: 커서가 <u> 안에 있거나 선택 텍스트가 <u>로 감싸져 있으면 제거, 아니면 추가 */
+export const underlineCommand: ICommand = {
+  name: 'underline',
+  keyCommand: 'underline',
+  buttonProps: {
+    'aria-label': '밑줄',
+    title: '밑줄',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(Underline, { size: 14 }),
+  execute: (state, api) => {
+    // 선택 없이 커서가 <u>...</u> 안에 있으면 → <u> 전체 선택 후 제거
+    if (!state.selectedText) {
+      const uRange = getEnclosingURange(state.text, state.selection.start)
+      if (uRange) {
+        const inner = state.text.slice(
+          uRange.start + '<u>'.length,
+          uRange.end - '</u>'.length
+        )
+        api.setSelectionRange(uRange)
+        api.replaceSelection(inner)
+        return
+      }
+    }
+    applyInline(state, api, (text) => {
+      const uMatch = text.match(/^<u>([\s\S]*)<\/u>$/)
+      return uMatch ? uMatch[1] : `<u>${text}</u>`
+    })
+  },
+}
+
+export function makeColorCommand(
+  name: string,
+  label: string,
+  icon: React.ReactElement,
+  colors: string[],
+  wrap: (color: string, text: string) => string
+): ICommand {
+  return {
+    name,
+    keyCommand: 'group',
+    groupName: name,
+    // onMouseDown: preventDefault → 팔레트 클릭 시 에디터 포커스/선택 영역 유지
+    buttonProps: {
+      'aria-label': label,
+      title: label,
+      onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+        e.preventDefault(),
+    },
+    icon,
+    children: ({ close, getState, textApi }) =>
+      React.createElement(
+        'div',
+        {
+          className: 'color-palette',
+          onMouseDown: (e: React.MouseEvent) => e.preventDefault(),
+        },
+        colors.map((color) =>
+          React.createElement('div', {
+            key: color,
+            className: 'color-swatch',
+            style: { background: color },
+            'data-white': color === '#ffffff' ? 'true' : undefined,
+            title: color === '#ffffff' ? '흰색' : color,
+            onClick: () => {
+              applyInlineFromDropdown(getState, textApi, (t) => wrap(color, t))
+              close()
+            },
+          })
+        )
+      ),
+    execute: () => {},
+  }
+}
+
+/**
+ * 배경색 커맨드.
+ * 기존 <mark> 방식 대신 <span style="background-color: ...">을 사용합니다.
+ * - font-size, color 등 다른 스타일과 같은 <span>에 병합되어
+ *   폰트 크기가 클 때 배경이 텍스트를 벗어나는 CSS 문제를 방지합니다.
+ * - 레거시 <mark> 콘텐츠는 색상 변경/제거 시 <span>으로 변환합니다.
+ */
+export const bgColorCommand: ICommand = {
+  name: 'bg-color',
+  keyCommand: 'group',
+  groupName: 'bg-color',
+  buttonProps: {
+    'aria-label': '배경색',
+    title: '배경색',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(
+    'span',
+    { style: { display: 'inline-flex', alignItems: 'center', gap: 3 } },
+    React.createElement('span', {
+      style: {
+        width: 16,
+        height: 16,
+        borderRadius: 3,
+        background: '#4285f4',
+        border: '1px solid rgba(0,0,0,0.12)',
+        display: 'inline-block',
+      },
+    }),
+    React.createElement(ChevronDown, { size: 10 })
+  ),
+  children: ({ close, getState, textApi }) =>
+    React.createElement(
+      'div',
+      {
+        className: 'bg-color-popup',
+        onMouseDown: (e: React.MouseEvent) => e.preventDefault(),
+      },
+      // ── 배경 제거 버튼 ──
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          className: 'bg-color-remove-btn',
+          onClick: () => {
+            const s = safeGetState(getState)
+            if (s && textApi) {
+              // 레거시: 커서가 <mark> 안에 있으면 mark 태그 전체 제거
+              const markRange = getEnclosingMarkRange(s.text, s.selection.start)
+              if (markRange && !s.selectedText) {
+                const inner = s.text
+                  .slice(markRange.start, markRange.end)
+                  .replace(/<mark[^>]*>([\s\S]*?)<\/mark>/g, '$1')
+                if (
+                  !replaceInText(
+                    textApi,
+                    s.text,
+                    markRange.start,
+                    markRange.end,
+                    inner
+                  )
+                ) {
+                  textApi.setSelectionRange(markRange)
+                  textApi.replaceSelection(inner)
+                }
+                close()
+                return
+              }
+            }
+            // 신규: span의 background-color 속성 제거 + 레거시 mark 제거
+            applyInlineFromDropdown(getState, textApi, (t) => {
+              const withoutMark = t.replace(
+                /<mark[^>]*>([\s\S]*?)<\/mark>/g,
+                '$1'
+              )
+              return stripStyleProp(withoutMark, 'background-color')
+            })
+            close()
+          },
+        },
+        '✕ 배경 제거'
+      ),
+      // ── 색상 팔레트 ──
+      React.createElement(
+        'div',
+        { className: 'color-palette' },
+        BG_PALETTE_COLORS.map((color) =>
+          React.createElement('div', {
+            key: color,
+            className: 'color-swatch',
+            style: {
+              background: color,
+              border:
+                color === '#ffffff'
+                  ? '1px solid #cdcdcd'
+                  : '1px solid rgba(0,0,0,0.12)',
+            },
+            title: color === '#ffffff' ? '흰색' : color,
+            onClick: () => {
+              const s = safeGetState(getState)
+              if (s && textApi) {
+                // 레거시: 커서가 <mark> 안에 있으면 mark를 span으로 변환
+                const markRange = getEnclosingMarkRange(
+                  s.text,
+                  s.selection.start
+                )
+                if (markRange && !s.selectedText) {
+                  const inner = s.text
+                    .slice(markRange.start, markRange.end)
+                    .replace(/<mark[^>]*>([\s\S]*?)<\/mark>/g, '$1')
+                  const replacement = wrapWithStyle(
+                    inner,
+                    'background-color',
+                    color
+                  )
+                  if (
+                    !replaceInText(
+                      textApi,
+                      s.text,
+                      markRange.start,
+                      markRange.end,
+                      replacement
+                    )
+                  ) {
+                    textApi.setSelectionRange(markRange)
+                    textApi.replaceSelection(replacement)
+                  }
+                  close()
+                  return
+                }
+              }
+              // 신규: background-color를 span style로 추가 (기존 span에 병합)
+              applyInlineFromDropdown(getState, textApi, (t) =>
+                wrapWithStyle(t, 'background-color', color)
+              )
+              close()
+            },
+          })
+        )
+      )
+    ),
+  execute: () => {},
+}
+
+export const textColorCommand: ICommand = makeColorCommand(
+  'text-color',
+  '글자색',
+  React.createElement(
+    'span',
+    {
+      style: {
+        display: 'inline-flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 2,
+        lineHeight: 1,
+      },
+    },
+    React.createElement(
+      'span',
+      { style: { fontWeight: 700, fontSize: 13 } },
+      'A'
+    ),
+    React.createElement('span', {
+      style: {
+        width: 14,
+        height: 3,
+        background: '#e53e3e',
+        borderRadius: 1,
+        display: 'block',
+      },
+    })
+  ),
+  TEXT_PALETTE_COLORS,
+  (color, text) => wrapWithStyle(text, 'color', color)
+)
+
+export const alignLeftCommand: ICommand = {
+  name: 'align-left',
+  keyCommand: 'align-left',
+  buttonProps: {
+    'aria-label': '왼쪽 정렬',
+    title: '왼쪽 정렬',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(AlignLeft, { size: 14 }),
+  execute: (state, api) =>
+    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'left')),
+}
+
+export const alignCenterCommand: ICommand = {
+  name: 'align-center',
+  keyCommand: 'align-center',
+  buttonProps: {
+    'aria-label': '가운데 정렬',
+    title: '가운데 정렬',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(AlignCenter, { size: 14 }),
+  execute: (state, api) =>
+    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'center')),
+}
+
+export const alignRightCommand: ICommand = {
+  name: 'align-right',
+  keyCommand: 'align-right',
+  buttonProps: {
+    'aria-label': '오른쪽 정렬',
+    title: '오른쪽 정렬',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(AlignRight, { size: 14 }),
+  execute: (state, api) =>
+    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'right')),
+}
+
+export const alignJustifyCommand: ICommand = {
+  name: 'align-justify',
+  keyCommand: 'align-justify',
+  buttonProps: {
+    'aria-label': '양쪽 정렬',
+    title: '양쪽 정렬',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(AlignJustify, { size: 14 }),
+  execute: (state, api) =>
+    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'justify')),
+}
+
+export const listDropdownCmd: ICommand = {
+  name: 'list-style',
+  keyCommand: 'group',
+  groupName: 'list-style',
+  buttonProps: {
+    'aria-label': '목록',
+    title: '목록',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(
+    'span',
+    { style: { display: 'inline-flex', alignItems: 'center', gap: 2 } },
+    React.createElement(List, { size: 13 }),
+    React.createElement(ChevronDown, { size: 10 })
+  ),
+  children: ({ close, getState, textApi }) =>
+    React.createElement(
+      'div',
+      {
+        className: 'toolbar-popup',
+        onMouseDown: (e: React.MouseEvent) => e.preventDefault(),
+      },
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: () => {
+            insertListPrefix(getState, textApi, '- ')
+            close()
+          },
+        },
+        '글머리 목록'
+      ),
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: () => {
+            insertListPrefix(getState, textApi, '1. ')
+            close()
+          },
+        },
+        '번호 목록'
+      ),
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: () => {
+            insertListPrefix(getState, textApi, '- [ ] ')
+            close()
+          },
+        },
+        '체크 목록'
+      )
+    ),
+  execute: () => {},
+}
+
+export const lineHeightCmd: ICommand = {
+  name: 'line-height',
+  keyCommand: 'group',
+  groupName: 'line-height',
+  buttonProps: {
+    'aria-label': '줄 간격',
+    title: '줄 간격',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(ArrowUpDown, { size: 14 }),
+  children: ({ close, getState, textApi }) =>
+    React.createElement(
+      'div',
+      {
+        className: 'toolbar-popup',
+        style: { minWidth: 80 },
+        onMouseDown: (e: React.MouseEvent) => e.preventDefault(),
+      },
+      ['1', '1.5', '2', '2.5', '3'].map((h) =>
+        React.createElement(
+          'button',
+          {
+            key: h,
+            type: 'button',
+            onClick: () => {
+              applyBlockFromDropdown(getState, textApi, (t) =>
+                wrapDivWithStyle(t, 'line-height', h)
+              )
+              close()
+            },
+          },
+          `${h}배`
+        )
+      )
+    ),
+  execute: () => {},
+}
+
+export const outdentCmd: ICommand = {
+  name: 'outdent',
+  keyCommand: 'outdent',
+  buttonProps: {
+    'aria-label': '내어쓰기',
+    title: '내어쓰기',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(IndentDecrease, { size: 14 }),
+  execute: (state, api) =>
+    applyBlock(state, api, (t) =>
+      t
+        .split('\n')
+        .map((l) => (l.startsWith('  ') ? l.slice(2) : l))
+        .join('\n')
+    ),
+}
+
+export const indentCmd: ICommand = {
+  name: 'indent',
+  keyCommand: 'indent',
+  buttonProps: {
+    'aria-label': '들여쓰기',
+    title: '들여쓰기',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(IndentIncrease, { size: 14 }),
+  execute: (state, api) =>
+    applyBlock(state, api, (t) =>
+      t
+        .split('\n')
+        .map((l) => `  ${l}`)
+        .join('\n')
+    ),
+}
+
+export const clearFormatCmd: ICommand = {
+  name: 'clear-format',
+  keyCommand: 'clear-format',
+  buttonProps: {
+    'aria-label': '서식 제거',
+    title: '서식 제거',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(RemoveFormatting, { size: 14 }),
+  execute: (state, api) =>
+    applyInline(state, api, (t) =>
+      t
+        .replace(/\*\*(.*?)\*\*/gs, '$1')
+        .replace(/\*(.*?)\*/gs, '$1')
+        .replace(/~~(.*?)~~/gs, '$1')
+        .replace(/<[^>]+>/gs, '')
+    ),
+}

--- a/src/components/community/MarkdownEditor/markdownEditorConstants.ts
+++ b/src/components/community/MarkdownEditor/markdownEditorConstants.ts
@@ -1,0 +1,104 @@
+import { defaultSchema } from 'rehype-sanitize'
+
+// style 속성 허용, blob: 이미지 src 허용, 스크립트/이벤트 핸들러는 차단
+export const editorSanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    '*': [...(defaultSchema.attributes?.['*'] ?? []), 'style'],
+  },
+  tagNames: [...(defaultSchema.tagNames ?? []), 'u', 'mark'],
+  protocols: {
+    ...defaultSchema.protocols,
+    src: [...(defaultSchema.protocols?.src ?? ['http', 'https']), 'blob'],
+  },
+}
+
+export const ACCEPTED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]
+
+// 웹폰트 로드 실패 시 시스템 폰트(fallback)로 자동 대체됨
+export const FONT_FAMILIES = [
+  { label: '기본서체', value: 'inherit' },
+  {
+    label: '노토 산스',
+    value: "'Noto Sans KR', 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif",
+  },
+  {
+    label: '나눔고딕',
+    value: "'Nanum Gothic', 'Dotum', '돋움', sans-serif",
+  },
+  {
+    label: '나눔명조',
+    value: "'Nanum Myeongjo', 'Batang', '바탕', serif",
+  },
+  {
+    label: 'Roboto',
+    value: "'Roboto', Arial, Helvetica, sans-serif",
+  },
+  {
+    label: 'Merriweather',
+    value: "'Merriweather', Georgia, 'Times New Roman', serif",
+  },
+  {
+    label: 'Source Code Pro',
+    value: "'Source Code Pro', 'Courier New', Consolas, monospace",
+  },
+]
+
+export const FONT_SIZES = [10, 12, 14, 16, 18, 20, 24, 28, 32]
+
+export const TEXT_PALETTE_COLORS = [
+  '#ffffff', // 흰색 (배경이 어두울 때 사용)
+  '#000000',
+  '#434343',
+  '#666666',
+  '#999999',
+  '#b7b7b7',
+  '#ff0000',
+  '#ff7700',
+  '#ffff00',
+  '#00ff00',
+  '#0000ff',
+  '#9900ff',
+  '#ff00ff',
+  '#00ffff',
+  '#ff6d6d',
+  '#ffd966',
+  '#93c47d',
+  '#76a5af',
+  '#4a86e8',
+  '#8e7cc3',
+  '#c27ba0',
+]
+
+// 배경색 전용 팔레트 (TEXT_PALETTE_COLORS 첫 번째 요소가 이미 '#ffffff'이므로 그대로 사용)
+export const BG_PALETTE_COLORS = TEXT_PALETTE_COLORS
+
+// 버튼 클릭 시 textarea 포커스/선택 영역 유지를 위한 공통 props
+export const NO_BLUR_PROPS = {
+  onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+}
+
+export const PILL: React.CSSProperties = {
+  borderRadius: 6,
+  background: '#f0f2f5',
+  border: '1px solid #e2e8f0',
+  padding: '0 10px',
+  height: 26,
+  width: 'auto',
+  minWidth: 'auto',
+  fontSize: 12,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+  cursor: 'pointer',
+  color: '#374151',
+  fontWeight: 400,
+}
+
+export const UNDO_LIMIT = 50

--- a/src/components/community/MarkdownEditor/markdownEditorUtils.ts
+++ b/src/components/community/MarkdownEditor/markdownEditorUtils.ts
@@ -1,0 +1,527 @@
+export type EditorState = {
+  selectedText: string
+  text: string
+  selection: { start: number; end: number }
+}
+
+export type TextApiWithElement = {
+  replaceSelection: (t: string) => void
+  setSelectionRange: (r: { start: number; end: number }) => void
+  textArea?: HTMLTextAreaElement
+}
+
+/** getState() 결과에서 전체 상태를 안전하게 꺼냅니다. */
+export function safeGetState(
+  getState?: () => false | EditorState
+): EditorState | null {
+  const s = getState?.()
+  return s && 'text' in s ? s : null
+}
+
+/** 커서가 HTML 태그 내부(<...> 사이)에 있는지 확인합니다. */
+export function isCursorInsideTag(text: string, cursor: number): boolean {
+  const lastOpen = text.lastIndexOf('<', cursor - 1)
+  if (lastOpen === -1) return false
+  const lastClose = text.lastIndexOf('>', cursor - 1)
+  return lastOpen > lastClose
+}
+
+/**
+ * 커서가 닫는 HTML 태그(</tag>) 직후에 연속으로 위치한 경우,
+ * 태그 스택 내부의 실제 콘텐츠 끝 위치로 이동합니다.
+ * 이미 콘텐츠 위치이거나 태그 내부이면 원래 cursor를 그대로 반환합니다.
+ *
+ * 예: `<mark><span>content</span></mark>|` → content 끝 위치
+ *     `<u>content</u>|`                   → content 끝 위치
+ *
+ * 이를 통해 배경색·밑줄 등 HTML 태그 기반 서식 적용 후에도
+ * 곧바로 다른 서식(글자색, 폰트 크기 등)을 연속 적용할 수 있습니다.
+ */
+export function getEffectiveCursor(text: string, cursor: number): number {
+  let pos = cursor
+  // 실제 에디터에서 중첩 깊이는 3-4단계 이하이므로 8은 충분한 안전 마진
+  const MAX_DEPTH = 8
+  for (let i = 0; i < MAX_DEPTH; i++) {
+    const before = text.slice(0, pos)
+    const m = before.match(/<\/\w+>$/)
+    if (!m) break
+    const candidate = pos - m[0].length
+    if (isCursorInsideTag(text, candidate)) break
+    // 후보 위치 바로 앞이 실제 콘텐츠 문자이면 도달
+    if (candidate > 0 && /[^\s<>]/.test(text[candidate - 1])) {
+      return candidate
+    }
+    pos = candidate
+  }
+  return cursor
+}
+
+/** 커서 위치 기준 현재 단어 범위를 반환합니다 (인라인 서식용).
+ *  HTML 태그 문자(<, >)에서 단어 경계로 처리해 태그 내용 선택을 방지합니다.
+ *
+ *  커서가 닫는 태그 뒤에 위치한 경우 getEffectiveCursor로 실제 콘텐츠 위치를 구한 뒤 재탐색합니다.
+ *  중첩 태그(`</span></mark>|` 등)도 재귀적으로 통과합니다. */
+export function getWordRange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  if (isCursorInsideTag(text, cursor)) return null
+  let start = cursor
+  let end = cursor
+  while (start > 0 && /[^\s<>]/.test(text[start - 1])) start--
+  while (end < text.length && /[^\s<>]/.test(text[end])) end++
+  if (start < end) return { start, end }
+
+  // 단어 미발견: 닫는 태그 뒤에 커서가 있으면 실제 콘텐츠 위치로 이동 후 재탐색
+  const effective = getEffectiveCursor(text, cursor)
+  if (effective === cursor) return null
+  if (isCursorInsideTag(text, effective)) return null
+  let s = effective
+  let e = effective
+  while (s > 0 && /[^\s<>]/.test(text[s - 1])) s--
+  while (e < text.length && /[^\s<>]/.test(text[e])) e++
+  return s < e ? { start: s, end: e } : null
+}
+
+/** 커서를 감싸는 가장 가까운 <span style="...">...</span> 의 범위를 반환합니다.
+ *  이미 스타일이 적용된 span에 다시 서식을 적용할 때 중첩 방지용으로 사용합니다.
+ *  커서가 </span> 바로 뒤(spanEnd)에 있는 경우도 포함합니다. */
+export function getEnclosingSpanRange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  // 순방향으로 모든 <span>을 찾아 커서가 포함되는지 확인합니다.
+  // cursor <= spanEnd 조건으로 </span> 바로 뒤에 커서가 있을 때도 매칭됩니다.
+  const spanOpenRe = /<span\b[^>]*>/gi
+  let match: RegExpExecArray | null
+  while ((match = spanOpenRe.exec(text)) !== null) {
+    const spanStart = match.index
+    const openEnd = spanStart + match[0].length
+    const closeIdx = text.indexOf('</span>', openEnd)
+    if (closeIdx === -1) continue
+    const spanEnd = closeIdx + '</span>'.length
+    if (cursor >= spanStart && cursor <= spanEnd) {
+      return { start: spanStart, end: spanEnd }
+    }
+  }
+  return null
+}
+
+/** 커서 위치 기준 현재 줄 범위를 반환합니다 (블록 서식용). */
+export function getLineRange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  if (isCursorInsideTag(text, cursor)) return null
+  let start = cursor
+  let end = cursor
+  while (start > 0 && text[start - 1] !== '\n') start--
+  while (end < text.length && text[end] !== '\n') end++
+  return start < end ? { start, end } : null
+}
+
+/**
+ * 번호 목록에서 Tab/Shift+Tab 시 들여쓰기 레벨에 맞는 다음 번호를 계산합니다.
+ * beforeIndex 이전 줄들을 역방향으로 탐색해 targetIndent 레벨의 마지막 번호 + 1을 반환합니다.
+ */
+export function computeNextNumber(
+  lines: string[],
+  beforeIndex: number,
+  targetIndent: string
+): number {
+  for (let i = beforeIndex - 1; i >= 0; i--) {
+    const m = lines[i].match(/^(\s*)(\d+)\. /)
+    if (!m) continue
+    if (m[1] === targetIndent) return parseInt(m[2], 10) + 1
+    if (m[1].length < targetIndent.length) break
+  }
+  return 1
+}
+
+/**
+ * fromIndex부터 targetIndent 레벨의 번호 목록 항목들을 순차적으로 재번호합니다.
+ * 더 깊은 레벨(하위 목록)은 건너뛰고, 더 얕은 레벨에서 중단합니다.
+ */
+export function renumberFrom(
+  lines: string[],
+  fromIndex: number,
+  targetIndent: string
+): string[] {
+  const result = [...lines]
+  let counter = computeNextNumber(result, fromIndex, targetIndent)
+  for (let i = fromIndex; i < result.length; i++) {
+    const m = result[i].match(/^(\s*)(\d+)\. (.*)/)
+    if (!m) continue
+    if (m[1].length < targetIndent.length) break
+    if (m[1] === targetIndent) {
+      result[i] = `${targetIndent}${counter}. ${m[3]}`
+      counter++
+    }
+  }
+  return result
+}
+
+/**
+ * execute 핸들러에서 선택 영역이 없으면 현재 단어를 자동 선택 후 wrapFn 적용.
+ * 인라인 서식(밑줄, 글자색 등)에 사용합니다.
+ */
+export function applyInline(
+  state: EditorState,
+  api: {
+    replaceSelection: (t: string) => void
+    setSelectionRange: (r: { start: number; end: number }) => void
+  },
+  wrapFn: (text: string) => string
+) {
+  if (state.selectedText) {
+    api.replaceSelection(wrapFn(state.selectedText))
+    return
+  }
+  const range = getWordRange(state.text, state.selection.start)
+  if (range) {
+    api.setSelectionRange(range)
+    api.replaceSelection(wrapFn(state.text.slice(range.start, range.end)))
+  }
+}
+
+/**
+ * execute 핸들러에서 선택 영역이 없으면 현재 줄을 자동 선택 후 wrapFn 적용.
+ * 블록 서식(정렬, 들여쓰기 등)에 사용합니다.
+ */
+export function applyBlock(
+  state: EditorState,
+  api: {
+    replaceSelection: (t: string) => void
+    setSelectionRange: (r: { start: number; end: number }) => void
+  },
+  wrapFn: (text: string) => string
+) {
+  if (state.selectedText) {
+    api.replaceSelection(wrapFn(state.selectedText))
+    return
+  }
+  const range = getLineRange(state.text, state.selection.start)
+  if (range) {
+    api.setSelectionRange(range)
+    api.replaceSelection(wrapFn(state.text.slice(range.start, range.end)))
+  }
+}
+
+/**
+ * textarea 값을 직접 교체하고 React onChange를 트리거합니다.
+ * setSelectionRange → replaceSelection 순서에서 insertTextAtPosition 내부의
+ * focus() 호출이 selection을 리셋하는 문제를 우회합니다.
+ *
+ * React native property setter hack:
+ * 원래 HTMLTextAreaElement.prototype.value setter를 호출하면 React가 변경을
+ * "dirty"로 인식한 뒤 input 이벤트에서 onChange를 정상 호출합니다.
+ */
+export function replaceInText(
+  textApi: TextApiWithElement,
+  fullText: string,
+  start: number,
+  end: number,
+  replacement: string
+): boolean {
+  const ta = textApi.textArea
+  if (!ta) return false
+  const newValue = fullText.slice(0, start) + replacement + fullText.slice(end)
+  const nativeSetter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    'value'
+  )?.set
+  if (!nativeSetter) return false
+  nativeSetter.call(ta, newValue)
+  ta.dispatchEvent(new Event('input', { bubbles: true }))
+  ta.selectionStart = ta.selectionEnd = start + replacement.length
+  return true
+}
+
+/**
+ * 드롭다운 children 핸들러용 인라인 서식 적용.
+ *
+ * 우선순위:
+ * 1. 커서가 기존 <span> 안에 있으면 → span 전체를 교체 (선택 여부 무관, 중첩 방지)
+ *    커서가 </mark></span> 등 닫는 태그 뒤에 있을 때도 getEffectiveCursor로
+ *    실제 콘텐츠 위치를 구해 span을 탐색합니다.
+ * 2. 선택 영역 있음 → 선택 텍스트에 적용
+ * 3. 선택 없음 → 현재 단어 선택 후 적용
+ * 4. 아무것도 없으면 → 아무것도 하지 않음 (빈 span 삽입 방지)
+ *
+ * replaceInText를 우선 사용해 setSelectionRange + replaceSelection 패턴에서
+ * 발생하는 focus() → selection 리셋 문제를 방지합니다.
+ */
+export function applyInlineFromDropdown(
+  getState: (() => false | EditorState) | undefined,
+  textApi: TextApiWithElement | undefined,
+  wrapFn: (text: string) => string
+) {
+  const s = safeGetState(getState)
+  if (!s || !textApi) return
+
+  // 1. 커서 시작 위치가 기존 <span> 안이면 span 전체를 교체 (중첩 방지)
+  //    닫는 태그 뒤에 커서가 있을 때는 effectiveCursor로 실제 콘텐츠 위치를 구해 재탐색
+  const effectiveCursor = getEffectiveCursor(s.text, s.selection.start)
+  const spanRange = getEnclosingSpanRange(s.text, effectiveCursor)
+  if (spanRange) {
+    const innerText = s.text.slice(spanRange.start, spanRange.end)
+    const replacement = wrapFn(innerText)
+    if (
+      !replaceInText(
+        textApi,
+        s.text,
+        spanRange.start,
+        spanRange.end,
+        replacement
+      )
+    ) {
+      textApi.setSelectionRange(spanRange)
+      textApi.replaceSelection(replacement)
+    }
+    return
+  }
+
+  // 2. 선택 영역이 있으면 선택 텍스트에 적용
+  if (s.selectedText) {
+    const replacement = wrapFn(s.selectedText)
+    if (
+      !replaceInText(
+        textApi,
+        s.text,
+        s.selection.start,
+        s.selection.end,
+        replacement
+      )
+    ) {
+      textApi.replaceSelection(replacement)
+    }
+    return
+  }
+
+  // 3. 선택 없음 → effectiveCursor 기준 단어를 선택 후 적용
+  const wordRange = getWordRange(s.text, effectiveCursor)
+  if (wordRange) {
+    const innerText = s.text.slice(wordRange.start, wordRange.end)
+    const replacement = wrapFn(innerText)
+    if (
+      !replaceInText(
+        textApi,
+        s.text,
+        wordRange.start,
+        wordRange.end,
+        replacement
+      )
+    ) {
+      textApi.setSelectionRange(wordRange)
+      textApi.replaceSelection(replacement)
+    }
+  }
+  // 4. 아무것도 없으면 종료 (빈 <span></span> 삽입 안 함)
+}
+
+/**
+ * 드롭다운 children 핸들러용 블록 서식 적용.
+ * 선택 있음 → 선택 텍스트에 적용.
+ * 선택 없음 → wrapFn('') 를 커서 위치에 삽입.
+ */
+export function applyBlockFromDropdown(
+  getState: (() => false | EditorState) | undefined,
+  textApi: TextApiWithElement | undefined,
+  wrapFn: (text: string) => string
+) {
+  const s = safeGetState(getState)
+  if (!s || !textApi) return
+  if (s.selectedText) {
+    textApi.replaceSelection(wrapFn(s.selectedText))
+    return
+  }
+  textApi.replaceSelection(wrapFn(''))
+}
+
+/**
+ * 목록 전용 삽입 함수.
+ * 선택 있음 → 각 줄 앞에 prefix 추가.
+ * 선택 없음 → 현재 줄의 맨 앞으로 커서 이동 후 prefix 삽입.
+ *   textarea.selectionStart/End 를 직접 수정해 setSelectionRange(→ focus()) 호출을 피합니다.
+ */
+export function insertListPrefix(
+  getState: (() => false | EditorState) | undefined,
+  textApi: TextApiWithElement | undefined,
+  prefix: string
+) {
+  const s = safeGetState(getState)
+  if (!s || !textApi) return
+
+  if (s.selectedText) {
+    const lines = s.selectedText
+      .split('\n')
+      .map((l) => `${prefix}${l}`)
+      .join('\n')
+    textApi.replaceSelection(lines)
+    return
+  }
+
+  // 선택 없음: 줄 시작 위치를 계산하고 직접 selectionStart/End 설정
+  const lineStart = s.text.lastIndexOf('\n', s.selection.start - 1) + 1
+  const nextNewline = s.text.indexOf('\n', lineStart)
+  const lineEnd = nextNewline === -1 ? s.text.length : nextNewline
+  const ta = (textApi as TextApiWithElement).textArea
+  if (ta) {
+    ta.selectionStart = lineStart
+    ta.selectionEnd = lineStart
+  }
+  textApi.replaceSelection(prefix)
+  // prefix 삽입 후 커서를 줄 끝으로 이동
+  if (ta) {
+    const newCursorPos = lineEnd + prefix.length
+    ta.selectionStart = newCursorPos
+    ta.selectionEnd = newCursorPos
+  }
+}
+
+/**
+ * 선택 텍스트가 이미 <span style="..."> 이면 해당 CSS 속성만 교체/추가하고,
+ * 그렇지 않으면 새 <span>으로 감쌉니다.
+ * 중첩 span 누적을 방지합니다.
+ */
+export function wrapWithStyle(
+  selected: string,
+  property: string,
+  value: string
+): string {
+  const match = selected.match(/^<span style="([^"]*)">([\s\S]*)<\/span>$/)
+  if (match) {
+    const existingStyle = match[1]
+    const inner = match[2]
+    const propRe = new RegExp(`(^|;\\s*)${property}\\s*:[^;]*`, 'i')
+    let newStyle: string
+    if (propRe.test(existingStyle)) {
+      newStyle = existingStyle
+        .replace(
+          new RegExp(`${property}\\s*:[^;]*`, 'i'),
+          `${property}: ${value}`
+        )
+        .replace(/^;\s*/, '')
+        .trim()
+    } else if (existingStyle) {
+      newStyle = `${existingStyle}; ${property}: ${value}`
+    } else {
+      newStyle = `${property}: ${value}`
+    }
+    return `<span style="${newStyle}">${inner}</span>`
+  }
+  return `<span style="${property}: ${value}">${selected}</span>`
+}
+
+/**
+ * 선택 텍스트가 이미 <mark style="..."> 이면 background-color만 교체하고,
+ * 그렇지 않으면 새 <mark>으로 감쌉니다.
+ */
+export function wrapMarkWithStyle(selected: string, color: string): string {
+  const match = selected.match(/^<mark style="([^"]*)">([\s\S]*)<\/mark>$/)
+  if (match) {
+    const existingStyle = match[1]
+    const inner = match[2]
+    const newStyle = existingStyle
+      .replace(/background-color\s*:[^;]*/i, `background-color: ${color}`)
+      .replace(/^;\s*/, '')
+      .trim()
+    return `<mark style="${newStyle}">${inner}</mark>`
+  }
+  return `<mark style="background-color: ${color}">${selected}</mark>`
+}
+
+/**
+ * span 요소의 style 속성에서 특정 CSS 프로퍼티를 제거합니다.
+ * 제거 후 style이 비어지면 span 태그 자체를 제거하고 내용만 남깁니다.
+ * 배경색 제거 시 사용합니다.
+ */
+export function stripStyleProp(html: string, property: string): string {
+  const propRe = new RegExp(`${property}\\s*:[^;]*(;\\s*)?`, 'gi')
+  // non-greedy([\s\S]*?)를 사용해 첫 번째 </span>에서 멈춥니다.
+  // 중첩 span의 경우 replacement의 `${inner}</span>` 패턴이 닫는 태그를 재구성하므로
+  // 나머지 </span>이 올바르게 남아 구조가 유지됩니다.
+  return html.replace(
+    /<span style="([^"]*)">([\s\S]*?)<\/span>/gi,
+    (_, style, inner) => {
+      const newStyle = style
+        .replace(propRe, '')
+        .replace(/;{2,}/g, ';')
+        .replace(/^;+|;+$/g, '')
+        .trim()
+      return newStyle ? `<span style="${newStyle}">${inner}</span>` : inner
+    }
+  )
+}
+
+/**
+ * 선택 텍스트가 이미 <div style="..."> 이면 해당 CSS 속성만 교체/추가하고,
+ * 그렇지 않으면 새 <div>로 감쌉니다.
+ * 중첩 div 누적을 방지합니다.
+ */
+export function wrapDivWithStyle(
+  selected: string,
+  property: string,
+  value: string
+): string {
+  const match = selected.match(/^<div style="([^"]*)">([\s\S]*)<\/div>$/)
+  if (match) {
+    const existingStyle = match[1]
+    const inner = match[2]
+    const propRe = new RegExp(`${property}\\s*:[^;]*`, 'i')
+    let newStyle: string
+    if (propRe.test(existingStyle)) {
+      newStyle = existingStyle
+        .replace(propRe, `${property}: ${value}`)
+        .replace(/^;\s*/, '')
+        .trim()
+    } else if (existingStyle) {
+      newStyle = `${existingStyle}; ${property}: ${value}`
+    } else {
+      newStyle = `${property}: ${value}`
+    }
+    return `<div style="${newStyle}">${inner}</div>`
+  }
+  return `<div style="${property}: ${value}">${selected}</div>`
+}
+
+/** 커서를 감싸는 가장 가까운 <mark style="...">...</mark> 의 범위를 반환합니다.
+ *  배경색이 이미 적용된 mark에 다시 색상을 적용하거나 제거할 때 사용합니다.
+ *  커서가 </mark> 바로 뒤에 있는 경우도 포함합니다. */
+export function getEnclosingMarkRange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  const markOpenRe = /<mark\b[^>]*>/gi
+  let match: RegExpExecArray | null
+  while ((match = markOpenRe.exec(text)) !== null) {
+    const markStart = match.index
+    const openEnd = markStart + match[0].length
+    const closeIdx = text.indexOf('</mark>', openEnd)
+    if (closeIdx === -1) continue
+    const markEnd = closeIdx + '</mark>'.length
+    if (cursor >= markStart && cursor <= markEnd) {
+      return { start: markStart, end: markEnd }
+    }
+  }
+  return null
+}
+
+/** 커서를 감싸는 <u>...</u> 범위를 반환합니다. </u> 바로 뒤 커서도 포함합니다. */
+export function getEnclosingURange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  const re = /<u>/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text)) !== null) {
+    const uStart = m.index
+    const closeIdx = text.indexOf('</u>', uStart + m[0].length)
+    if (closeIdx === -1) continue
+    const uEnd = closeIdx + '</u>'.length
+    if (cursor >= uStart && cursor <= uEnd) {
+      return { start: uStart, end: uEnd }
+    }
+  }
+  return null
+}

--- a/src/components/community/MarkdownEditor/useImageUpload.ts
+++ b/src/components/community/MarkdownEditor/useImageUpload.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React from 'react'
+import { type ICommand } from '@uiw/react-md-editor'
+import { usePresignedUrl } from '@/features/posts/write'
+import { ACCEPTED_IMAGE_TYPES } from './markdownEditorConstants'
+
+export function useImageUpload(
+  valueRef: React.RefObject<string>,
+  onChange: (v: string) => void
+) {
+  const { mutateAsync: getPresignedUrl } = usePresignedUrl()
+  const [isUploading, setIsUploading] = useState(false)
+  const [imageError, setImageError] = useState<string | null>(null)
+  const objectUrlsRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    const urls = objectUrlsRef.current
+    return () => {
+      urls.forEach((url) => URL.revokeObjectURL(url))
+    }
+  }, [])
+
+  const uploadImageFile = useCallback(
+    async (file: File, insertFn: (md: string) => void) => {
+      if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+        setImageError('JPG, PNG, GIF, WEBP 형식만 업로드할 수 있습니다.')
+        return
+      }
+      setImageError(null)
+      setIsUploading(true)
+      const objectUrl = URL.createObjectURL(file)
+      objectUrlsRef.current.add(objectUrl)
+      insertFn(`![${file.name}](${objectUrl})`)
+      try {
+        const { presigned_url, img_url } = await getPresignedUrl({
+          file_name: file.name,
+        })
+        try {
+          await fetch(presigned_url, {
+            method: 'PUT',
+            body: file,
+            headers: { 'Content-Type': file.type },
+          })
+        } catch (err) {
+          if (!import.meta.env.DEV) throw err
+          // DEV(MSW) 환경에서는 S3 업로드 실패 무시 — objectUrl로 미리보기 유지
+        }
+        if (!import.meta.env.DEV) {
+          onChange(valueRef.current.replaceAll(objectUrl, img_url))
+          URL.revokeObjectURL(objectUrl)
+          objectUrlsRef.current.delete(objectUrl)
+        }
+      } catch {
+        URL.revokeObjectURL(objectUrl)
+        objectUrlsRef.current.delete(objectUrl)
+        setImageError('이미지 업로드에 실패했습니다. 다시 시도해 주세요.')
+      } finally {
+        setIsUploading(false)
+      }
+    },
+    [getPresignedUrl, onChange, valueRef]
+  )
+
+  const imageCommand: ICommand = useMemo(
+    () => ({
+      name: 'image',
+      keyCommand: 'image',
+      buttonProps: {
+        'aria-label': '이미지 업로드',
+        title: '이미지 업로드',
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
+      },
+      icon: React.createElement(
+        'svg',
+        { width: 14, height: 14, viewBox: '0 0 20 20' },
+        React.createElement('path', {
+          fill: 'currentColor',
+          d: 'M15 9c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm4-7H1c-.55 0-1 .45-1 1v14c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 13l-6-5-2 2-4-5-4 6V4h16v11z',
+        })
+      ),
+      execute: (_state, api) => {
+        const input = document.createElement('input')
+        input.type = 'file'
+        input.accept = ACCEPTED_IMAGE_TYPES.join(',')
+        input.onchange = async () => {
+          const file = input.files?.[0]
+          if (!file) return
+          await uploadImageFile(file, (md) => api.replaceSelection(md))
+        }
+        input.click()
+      },
+    }),
+    [uploadImageFile]
+  )
+
+  return {
+    isUploading,
+    imageError,
+    objectUrlsRef,
+    uploadImageFile,
+    imageCommand,
+  }
+}

--- a/src/components/community/MarkdownEditor/useMarkdownHistory.ts
+++ b/src/components/community/MarkdownEditor/useMarkdownHistory.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React from 'react'
+import { Undo2, Redo2 } from 'lucide-react'
+import { type ICommand } from '@uiw/react-md-editor'
+import { UNDO_LIMIT } from './markdownEditorConstants'
+
+export function useMarkdownHistory(
+  value: string,
+  onChange: (v: string) => void
+) {
+  const valueRef = useRef(value)
+  const [undoStack, setUndoStack] = useState<string[]>([])
+  const [redoStack, setRedoStack] = useState<string[]>([])
+
+  useEffect(() => {
+    valueRef.current = value
+  }, [value])
+
+  const handleChange = (newValue: string) => {
+    setUndoStack((prev) => {
+      const next = [...prev, valueRef.current]
+      return next.length > UNDO_LIMIT ? next.slice(-UNDO_LIMIT) : next
+    })
+    setRedoStack([])
+    onChange(newValue)
+  }
+
+  const handleUndo = useCallback(() => {
+    if (undoStack.length === 0) return
+    const prev = undoStack[undoStack.length - 1]
+    setRedoStack((r) => [...r, valueRef.current])
+    setUndoStack((u) => u.slice(0, -1))
+    onChange(prev)
+  }, [undoStack, onChange])
+
+  const handleRedo = useCallback(() => {
+    if (redoStack.length === 0) return
+    const next = redoStack[redoStack.length - 1]
+    setUndoStack((u) => [...u, valueRef.current])
+    setRedoStack((r) => r.slice(0, -1))
+    onChange(next)
+  }, [redoStack, onChange])
+
+  const undoCommand = useMemo<ICommand>(
+    () => ({
+      name: 'undo',
+      keyCommand: 'undo',
+      buttonProps: {
+        'aria-label': '실행 취소',
+        title: '실행 취소',
+        'data-inactive': undoStack.length === 0 ? 'true' : undefined,
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
+      } as React.ButtonHTMLAttributes<HTMLButtonElement>,
+      icon: React.createElement(Undo2, { size: 14 }),
+      execute: handleUndo,
+    }),
+    [undoStack.length, handleUndo]
+  )
+
+  const redoCommand = useMemo<ICommand>(
+    () => ({
+      name: 'redo',
+      keyCommand: 'redo',
+      buttonProps: {
+        'aria-label': '다시 실행',
+        title: '다시 실행',
+        'data-inactive': redoStack.length === 0 ? 'true' : undefined,
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
+      } as React.ButtonHTMLAttributes<HTMLButtonElement>,
+      icon: React.createElement(Redo2, { size: 14 }),
+      execute: handleRedo,
+    }),
+    [redoStack.length, handleRedo]
+  )
+
+  return {
+    valueRef,
+    undoStack,
+    redoStack,
+    setUndoStack,
+    setRedoStack,
+    handleChange,
+    undoCommand,
+    redoCommand,
+  }
+}

--- a/src/components/community/PostForm/PostForm.tsx
+++ b/src/components/community/PostForm/PostForm.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import type { Category } from '@/features/posts/categories'
-import { usePresignedUrl } from '@/features/posts/write'
 import { Dropdown } from '@/components/common/Dropdown'
 import { MarkdownEditor } from '../MarkdownEditor'
 import { SubmitButton } from '../SubmitButton'
@@ -56,7 +55,6 @@ export function PostForm({
     content: defaultValues?.content ?? '',
   }))
   const [errors, setErrors] = useState<PostFormErrors>({})
-  const { mutateAsync: getPresignedUrl } = usePresignedUrl()
 
   const categoryOptions = categories.map((c) => ({
     value: String(c.id),
@@ -69,18 +67,6 @@ export function PostForm({
   ) => {
     setValues((prev) => ({ ...prev, [key]: value }))
     if (errors[key]) setErrors((prev) => ({ ...prev, [key]: undefined }))
-  }
-
-  const handleImageUpload = async (file: File): Promise<string> => {
-    const { presigned_url, img_url } = await getPresignedUrl({
-      file_name: file.name,
-    })
-    await fetch(presigned_url, {
-      method: 'PUT',
-      body: file,
-      headers: { 'Content-Type': file.type },
-    })
-    return img_url
   }
 
   const validate = (): boolean => {
@@ -157,7 +143,6 @@ export function PostForm({
       <MarkdownEditor
         value={values.content}
         onChange={(v) => handleChange('content', v)}
-        onImageUpload={handleImageUpload}
         error={errors.content}
       />
 

--- a/src/features/posts/delete/handler.ts
+++ b/src/features/posts/delete/handler.ts
@@ -1,14 +1,10 @@
 import { delay, http, HttpResponse } from 'msw'
 import { postMockStore } from '../mockStore'
 import type { PostDeleteResponse } from './types'
-import { postMockStore } from '../mockStore'
 
 export const postDeleteHandlers = [
   http.delete('/api/v1/posts/:post_id', async ({ params }) => {
     await delay(300)
-<<<<<<< feature/markdown-editor
-    postMockStore.remove(Number(params.post_id))
-=======
     const postId = Number(params.post_id)
 
     if (postId === 999) {
@@ -18,9 +14,8 @@ export const postDeleteHandlers = [
       )
     }
 
-    postMockStore.posts.delete(postId)
+    postMockStore.remove(postId)
 
->>>>>>> dev
     const body: PostDeleteResponse = {
       detail: '게시글이 삭제되었습니다.',
     }

--- a/src/features/posts/edit/handler.ts
+++ b/src/features/posts/edit/handler.ts
@@ -1,9 +1,5 @@
 import { http, HttpResponse } from 'msw'
-<<<<<<< feature/markdown-editor
-import { postMockStore } from '../mockStore'
-=======
 import { postMockStore, MOCK_CATEGORIES } from '../mockStore'
->>>>>>> dev
 
 export const editHandlers = [
   http.put('/api/v1/posts/:postId', async ({ request, params }) => {
@@ -15,13 +11,6 @@ export const editHandlers = [
       )
     }
     const postId = Number(params.postId)
-<<<<<<< feature/markdown-editor
-    postMockStore.update(postId, {
-      title: body.title as string,
-      content: body.content as string,
-      category_id: Number(body.category_id),
-    })
-=======
     const categoryId = Number(body.category_id)
     const category = MOCK_CATEGORIES.find((c) => c.id === categoryId)
 
@@ -38,7 +27,6 @@ export const editHandlers = [
       })
     }
 
->>>>>>> dev
     return HttpResponse.json({
       id: postId,
       title: body.title as string,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,12 +5,12 @@ import { QueryProvider } from './providers/QueryProvider'
 import './App.css'
 import App from './App'
 
-async function enableMocking() {
-  if (import.meta.env.DEV) {
-    const { worker } = await import('./mocks/browser')
-    return worker.start({ onUnhandledRequest: 'bypass' })
-  }
-}
+// async function enableMocking() {
+//   if (import.meta.env.DEV) {
+//     const { worker } = await import('./mocks/browser')
+//     return worker.start({ onUnhandledRequest: 'bypass' })
+//   }
+// }
 
 function renderApp() {
   createRoot(document.getElementById('root')!).render(
@@ -24,9 +24,10 @@ function renderApp() {
   )
 }
 
-enableMocking()
-  .then(() => renderApp())
-  .catch((error) => {
-    console.error('MSW 초기화 실패:', error)
-    renderApp()
-  })
+// enableMocking()
+//   .then(() => renderApp())
+//   .catch((error) => {
+//     console.error('MSW 초기화 실패:', error)
+//     renderApp()
+//   })
+renderApp()


### PR DESCRIPTION
## 관련 이슈

- closes #91

## 작업 내용

- MarkdownEditor 단일 파일(1190줄)을 역할별 모듈 5개로 분리
- API 토큰 갱신 인터셉터에서 무한 루프를 일으키던 인스턴스 문제 수정

## 변경 사항

- `markdownEditorConstants.ts` — 상수 분리 (폰트, 이미지 타입, sanitize 스키마 등)
- `markdownEditorUtils.ts` — 순수 유틸 함수 분리 (서식 적용, 번호 목록 재번호 등)
- `markdownEditorCommands.ts` — 툴바 커맨드 정의 분리
- `useMarkdownHistory.ts` — Undo/Redo 히스토리 커스텀 훅 추출
- `useImageUpload.ts` — 이미지 업로드 커스텀 훅 추출
- `MarkdownEditor.tsx` — 위 모듈 조립만 담당하도록 축소
- `src/api/instance.ts` — `baseApi` 추출 (인터셉터 없는 순수 인스턴스)
- GFM 표준 기반 재작성 + rehype-sanitize 보안 강화
- 서식 중복 적용 방어, Enter/Tab 키 동작 개선

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다