### PR TITLE
feat: 루트 경로(/) → /community 자동 리다이렉트 추가 (#93)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,9 @@
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
         "react-router": "^7.13.2",
+        "react-router-dom": "^7.15.0",
         "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "tailwindcss": "^4.2.2",
         "zustand": "^5.0.12"
@@ -4106,6 +4108,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-select": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
@@ -7011,9 +7028,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
-      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -7030,6 +7047,22 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
+      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.15.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-router/node_modules/set-cookie-parser": {
@@ -7239,6 +7272,20 @@
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-slug": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
     "react-router": "^7.13.2",
+    "react-router-dom": "^7.15.0",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "tailwindcss": "^4.2.2",
     "zustand": "^5.0.12"

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -1,4 +1,3 @@
-import { Routes, Route } from 'react-router'
 import { DefaultLayout } from '@/components'
 import {
   CommunityListPage,
@@ -7,15 +6,19 @@ import {
   CommunityEditPage,
 } from '@/pages/community'
 import { ComponentShowcase } from '@/pages/ComponentShowcase'
+import { Navigate, Route, Routes } from 'react-router-dom'
 
 export function RouterProvider() {
   return (
     <Routes>
-      {/* Header + Footer */}
       <Route element={<DefaultLayout />}>
+        {/* / -> /community */}
+        <Route index element={<Navigate to="/community" replace />} />
+
         <Route path="community">
           <Route index element={<CommunityListPage />} />
           <Route path="write" element={<CommunityWritePage />} />
+
           <Route path=":postId">
             <Route index element={<CommunityDetailPage />} />
             <Route path="edit" element={<CommunityEditPage />} />


### PR DESCRIPTION
## 관련 이슈

- closes #93

## 작업 내용

- 루트 경로(/) 접속 시 /community로 자동 리다이렉트 추가

## 변경 사항

- `RouterProvider.tsx` — index route에 `<Navigate to="/community" replace />` 추가
- `package.json` — `react-router-dom` 의존성 추가

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다