### PR TITLE
[Refactor] 게시글 미리보기 이미지 수정

### DIFF
--- a/src/components/community/PostCard/PostCard.tsx
+++ b/src/components/community/PostCard/PostCard.tsx
@@ -6,6 +6,24 @@ export interface PostCardProps {
   onClick?: () => void
 }
 
+function extractFirstImage(text: string): string | null {
+  const match = /!\[([^\]]*)\]\(([^)]+)\)/.exec(text)
+  return match ? match[2] : null
+}
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, '$2')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/^[-*]{3,}\s*$/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
 function formatRelativeTime(isoString: string): string {
   const target = new Date(isoString).getTime()
   if (Number.isNaN(target)) return ''
@@ -76,7 +94,8 @@ function EyeIcon() {
 }
 
 export function PostCard({ post, onClick }: PostCardProps) {
-  const hasThumbnail = !!post.thumbnail
+  const effectiveThumbnail = post.thumbnail || extractFirstImage(post.content)
+  const hasThumbnail = !!effectiveThumbnail
 
   return (
     <article
@@ -111,7 +130,7 @@ export function PostCard({ post, onClick }: PostCardProps) {
                 : 'line-clamp-2 min-h-10.5',
             ].join(' ')}
           >
-            {post.content}
+            {stripMarkdown(post.content)}
           </p>
 
           {/* 하단 메타 */}
@@ -155,7 +174,7 @@ export function PostCard({ post, onClick }: PostCardProps) {
         {/* 썸네일 */}
         {hasThumbnail && (
           <img
-            src={post.thumbnail ?? ''}
+            src={effectiveThumbnail ?? ''}
             alt=""
             role="presentation"
             loading="lazy"

--- a/src/components/community/PostCard/PostCard.tsx
+++ b/src/components/community/PostCard/PostCard.tsx
@@ -110,7 +110,7 @@ export function PostCard({ post, onClick }: PostCardProps) {
         .filter(Boolean)
         .join(' ')}
     >
-      <div className="flex h-40.75 w-full justify-between overflow-hidden">
+      <div className="flex h-40.75 w-full justify-between gap-10 overflow-hidden">
         {/* 텍스트 영역 */}
         <div className="flex min-w-0 flex-1 flex-col gap-1.5 overflow-hidden">
           {/* 카테고리 */}

--- a/src/pages/community/CommunityListPage.tsx
+++ b/src/pages/community/CommunityListPage.tsx
@@ -28,9 +28,17 @@ const SORT_OPTIONS: { value: PostSortOption; label: string }[] = [
   { value: 'most_comments', label: '댓글순' },
 ]
 
-type CategoryTab = { value: string; label: string; categoryId: number | undefined }
+type CategoryTab = {
+  value: string
+  label: string
+  categoryId: number | undefined
+}
 
-const ALL_TAB: CategoryTab = { value: 'all', label: '전체', categoryId: undefined }
+const ALL_TAB: CategoryTab = {
+  value: 'all',
+  label: '전체',
+  categoryId: undefined,
+}
 
 function PencilIcon() {
   return (
@@ -226,7 +234,7 @@ export function CommunityListPage() {
             ref={tabsScrollRef}
             role="tablist"
             aria-label="게시글 카테고리"
-            className="flex min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            className="flex min-w-0 flex-1 scrollbar-none overflow-x-auto [&::-webkit-scrollbar]:hidden"
           >
             {categoryTabs.map((tab) => (
               <button


### PR DESCRIPTION
## 관련 이슈

- closes #107 

## 작업 내용

- 게시글 미리보기가 문자열에서 이미지로 보이도록 수정

## 변경 사항

- 게시글 미리보기에서 특수문자 제거, 이미지가 있을경우 이미지가 보이게 추가

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
