### PR TITLE
fix: Markdown 번호 목록 하위 항목 Enter 3번 상위 레벨 탈출 (#113)

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -128,7 +128,7 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
     event,
     client,
     requestId,
-    requestInterceptedAt,
+    requestInterceptedAt
   )
 
   // Send back the response clone for the "response:*" life-cycle events.
@@ -159,7 +159,7 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
           },
         },
       },
-      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+      responseClone.body ? [serializedRequest.body, responseClone.body] : []
     )
   }
 
@@ -225,7 +225,7 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
     if (acceptHeader) {
       const values = acceptHeader.split(',').map((value) => value.trim())
       const filteredValues = values.filter(
-        (value) => value !== 'msw/passthrough',
+        (value) => value !== 'msw/passthrough'
       )
 
       if (filteredValues.length > 0) {
@@ -263,7 +263,7 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
         ...serializedRequest,
       },
     },
-    [serializedRequest.body],
+    [serializedRequest.body]
   )
 
   switch (clientMessage.type) {

--- a/src/components/community/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/community/MarkdownEditor/MarkdownEditor.tsx
@@ -182,16 +182,52 @@ export function MarkdownEditor({
           return
         }
 
-        // 들여쓰기된 번호 목록 (빈 항목 → 상위 레벨로 복귀)
+        // 들여쓰기된 번호 목록 (빈 항목)
         const orderedEmptyMatch = line.match(/^( +)(\d+)\. $/)
         if (orderedEmptyMatch) {
           e.preventDefault()
           e.stopPropagation()
           const [, indent, numStr] = orderedEmptyMatch
-          const nextItem = `${indent}${parseInt(numStr, 10) + 1}. `
-          const newText =
-            text.slice(0, lineStart) + nextItem + text.slice(lineEnd)
-          applyText(ta, newText, lineStart + nextItem.length)
+
+          const prevLineEnd = lineStart - 1
+          const prevLineStart =
+            lineStart > 0 ? text.lastIndexOf('\n', prevLineEnd - 1) + 1 : 0
+          const prevLine =
+            lineStart > 0 ? text.slice(prevLineStart, prevLineEnd) : ''
+
+          if (prevLine === indent) {
+            // 3번째 엔터: 현재 줄을 부모 레벨 번호 목록으로 교체
+            const lines = text.split('\n')
+            const lineIndex = (text.slice(0, lineStart).match(/\n/g) ?? [])
+              .length
+            let parentIndent = ''
+            for (let i = lineIndex - 1; i >= 0; i--) {
+              const m = lines[i].match(/^(\s*)(\d+)\. /)
+              if (m && m[1].length < indent.length) {
+                parentIndent = m[1]
+                break
+              }
+            }
+            const parentNum = computeNextNumber(lines, lineIndex, parentIndent)
+            const newLine = `${parentIndent}${parentNum}. `
+            const newText =
+              text.slice(0, lineStart) + newLine + text.slice(lineEnd)
+            applyText(ta, newText, lineStart + newLine.length)
+          } else {
+            // 2번째 엔터: 들여쓰기 유지, 새 하위 번호 줄 추가
+            const nextNum = parseInt(numStr, 10) + 1
+            const nextItem = `${indent}${nextNum}. `
+            const newText =
+              text.slice(0, lineStart) +
+              indent +
+              `\n${nextItem}` +
+              text.slice(lineEnd)
+            applyText(
+              ta,
+              newText,
+              lineStart + indent.length + 1 + nextItem.length
+            )
+          }
           return
         }
 


### PR DESCRIPTION
## 관련 이슈

- closes #113

## 작업 내용

- Markdown 에디터의 번호 목록(numbered list) 하위 항목에서 Enter 3번 입력 시 상위 레벨로 탈출하는 기능 구현

## 변경 사항

- `src/components/community/MarkdownEditor/MarkdownEditor.tsx`
  - `orderedEmptyMatch` 핸들러에 3-Enter 탈출 로직 추가
  - **2번째 Enter**: 빈 번호 하위 항목에서 들여쓰기 줄 + 새 하위 번호 항목 생성
  - **3번째 Enter**: 이전 줄이 들여쓰기만인 경우 `computeNextNumber`로 부모 레벨 번호를 계산해 상위 번호 목록으로 복귀
  - 기존 글머리 목록(`- `, `* `)의 3-Enter 탈출 로직과 동일한 패턴으로 통일

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다