### PR TITLE
feat: role 기반 수강생 등록 메뉴 노출 조건 추가 (#124)

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -83,7 +83,8 @@ export function Header({
                 onClose={() => setDropdownOpen(false)}
                 nickname={user?.nickname ?? ''}
                 email={user?.email ?? ''}
-                enrollHref={ROUTES.SIGNUP.SELECT}
+                role={user?.role}
+                enrollHref={ROUTES.ENROLL}
                 mypageHref={
                   isAuthenticated ? ROUTES.MYPAGE.HOME : ROUTES.AUTH.LOGIN
                 }

--- a/src/components/layout/Header/ProfileDropdown.tsx
+++ b/src/components/layout/Header/ProfileDropdown.tsx
@@ -6,6 +6,7 @@ export interface ProfileDropdownProps {
   onClose: () => void
   nickname: string
   email: string
+  role?: 'user' | 'student' | 'admin'
   enrollHref?: string
   mypageHref?: string
   onLogout?: () => void
@@ -16,6 +17,7 @@ export function ProfileDropdown({
   onClose,
   nickname,
   email,
+  role,
   enrollHref,
   mypageHref,
   onLogout,
@@ -56,13 +58,15 @@ export function ProfileDropdown({
 
         {/* Menu */}
         <nav className="flex flex-col gap-1">
-          <a
-            href={enrollHref}
-            onClick={onClose}
-            className="hover:text-primary hover:bg-bg-accent text-text-heading inline-flex h-12 w-full items-center justify-start rounded-sm px-3 text-sm font-medium tracking-tight transition-colors duration-150"
-          >
-            수강생 등록
-          </a>
+          {role === 'user' && (
+            <a
+              href={enrollHref}
+              onClick={onClose}
+              className="hover:text-primary hover:bg-bg-accent text-text-heading inline-flex h-12 w-full items-center justify-start rounded-sm px-3 text-sm font-medium tracking-tight transition-colors duration-150"
+            >
+              수강생 등록
+            </a>
+          )}
           <a
             href={mypageHref}
             onClick={onClose}


### PR DESCRIPTION
## Summary

- `role === 'user'`인 경우에만 수강생 등록 메뉴 표시
- `role === 'student'` 또는 `role === 'admin'`은 수강생 등록 메뉴 숨김
- `ProfileDropdown`에 `role` prop 추가, `Header`에서 `user.role` 전달

## Test plan

- [ ] role이 'user'인 계정으로 로그인 시 수강생 등록 메뉴 표시 확인
- [ ] role이 'student' 또는 'admin'인 계정으로 로그인 시 수강생 등록 메뉴 미표시 확인

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)