### PR TITLE
fix: 댓글 정렬 기능 복구 및 기본값 오래된 순으로 변경

### DIFF
--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -46,7 +46,7 @@ export function CommunityComments({ postId }: Props) {
     isLoading,
     isError,
     error,
-  } = useCommentsInfiniteQuery(postId, sortOrder, Boolean(postId))
+  } = useCommentsInfiniteQuery(postId, Boolean(postId))
 
   const queryClient = useQueryClient()
   const { mutate: submitComment, isPending: isSubmitting } =
@@ -169,7 +169,13 @@ export function CommunityComments({ postId }: Props) {
     return () => observer.disconnect()
   }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
-  const allComments = data?.pages.flatMap((page) => page.results) ?? []
+  const allComments = (data?.pages.flatMap((page) => page.results) ?? []).sort(
+    (a, b) => {
+      const diff =
+        new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+      return sortOrder === 'oldest' ? diff : -diff
+    }
+  )
   const totalCount = data?.pages[0]?.count ?? 0
 
   if (isLoading) {

--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -30,7 +30,7 @@ export function CommunityComments({ postId }: Props) {
   const [inputValue, setInputValue] = useState('')
   const [submitError, setSubmitError] = useState(false)
   const [submitErrorMessage, setSubmitErrorMessage] = useState('')
-  const [sortOrder, setSortOrder] = useState<SortOrder>('latest')
+  const [sortOrder, setSortOrder] = useState<SortOrder>('oldest')
   const [deleteToast, setDeleteToast] = useState<{
     visible: boolean
     message: string
@@ -46,7 +46,7 @@ export function CommunityComments({ postId }: Props) {
     isLoading,
     isError,
     error,
-  } = useCommentsInfiniteQuery(postId, Boolean(postId))
+  } = useCommentsInfiniteQuery(postId, sortOrder, Boolean(postId))
 
   const queryClient = useQueryClient()
   const { mutate: submitComment, isPending: isSubmitting } =

--- a/src/features/posts/comments/queries.ts
+++ b/src/features/posts/comments/queries.ts
@@ -8,13 +8,9 @@ import type { Comment, CommentsResponse, CommentSubmitRequest } from './types'
 
 const PAGE_SIZE = 10
 
-export function useCommentsInfiniteQuery(
-  postId: number,
-  ordering: 'latest' | 'oldest' = 'oldest',
-  enabled = true
-) {
+export function useCommentsInfiniteQuery(postId: number, enabled = true) {
   return useInfiniteQuery({
-    queryKey: ['posts', postId, 'comments', ordering],
+    queryKey: ['posts', postId, 'comments'],
     queryFn: async ({ pageParam }) => {
       const response = await api.get<CommentsResponse>(
         `/api/v1/posts/${postId}/comments`,
@@ -22,7 +18,6 @@ export function useCommentsInfiniteQuery(
           params: {
             page: pageParam,
             page_size: PAGE_SIZE,
-            ordering: ordering === 'latest' ? '-created_at' : 'created_at',
           },
         }
       )

--- a/src/features/posts/comments/queries.ts
+++ b/src/features/posts/comments/queries.ts
@@ -8,9 +8,13 @@ import type { Comment, CommentsResponse, CommentSubmitRequest } from './types'
 
 const PAGE_SIZE = 10
 
-export function useCommentsInfiniteQuery(postId: number, enabled = true) {
+export function useCommentsInfiniteQuery(
+  postId: number,
+  ordering: 'latest' | 'oldest' = 'oldest',
+  enabled = true
+) {
   return useInfiniteQuery({
-    queryKey: ['posts', postId, 'comments'],
+    queryKey: ['posts', postId, 'comments', ordering],
     queryFn: async ({ pageParam }) => {
       const response = await api.get<CommentsResponse>(
         `/api/v1/posts/${postId}/comments`,
@@ -18,6 +22,7 @@ export function useCommentsInfiniteQuery(postId: number, enabled = true) {
           params: {
             page: pageParam,
             page_size: PAGE_SIZE,
+            ordering: ordering === 'latest' ? '-created_at' : 'created_at',
           },
         }
       )

--- a/src/features/posts/like/handler.ts
+++ b/src/features/posts/like/handler.ts
@@ -17,7 +17,7 @@ export const postLikeHandlers = [
     }
     return HttpResponse.json(body)
   }),
-  http.delete(apiUrl('/api/v1/posts/:post_id/like/cancel'), ({ params }) => {
+  http.delete(apiUrl('/api/v1/posts/:post_id/like'), ({ params }) => {
     const postId = Number(params.post_id)
     const newCount = Math.max(0, likeMockStore.getLikeCount(postId) - 1)
     likeMockStore.likeCountMap.set(postId, newCount)

--- a/src/features/posts/like/queries.ts
+++ b/src/features/posts/like/queries.ts
@@ -10,9 +10,7 @@ export const useTogglePostLike = (postId: number) => {
   return useMutation({
     mutationFn: async (isCurrentlyLiked: boolean) => {
       const { data } = isCurrentlyLiked
-        ? await api.delete<PostLikeResponse>(
-            `/api/v1/posts/${postId}/like/cancel`
-          )
+        ? await api.delete<PostLikeResponse>(`/api/v1/posts/${postId}/like`)
         : await api.post<PostLikeResponse>(`/api/v1/posts/${postId}/like`)
       return data
     },


### PR DESCRIPTION
## 관련 이슈

- closes #

## 작업 내용

- 정렬순 오래된순 모달 작동안되서 작동되게 수정




