### PR TITLE
fix: 좋아요 취소 엔드포인트 변경 (DELETE /like/cancel → DELETE /like)

### DIFF
--- a/src/features/posts/like/handler.ts
+++ b/src/features/posts/like/handler.ts
@@ -17,7 +17,7 @@ export const postLikeHandlers = [
     }
     return HttpResponse.json(body)
   }),
-  http.delete(apiUrl('/api/v1/posts/:post_id/like/cancel'), ({ params }) => {
+  http.delete(apiUrl('/api/v1/posts/:post_id/like'), ({ params }) => {
     const postId = Number(params.post_id)
     const newCount = Math.max(0, likeMockStore.getLikeCount(postId) - 1)
     likeMockStore.likeCountMap.set(postId, newCount)

--- a/src/features/posts/like/queries.ts
+++ b/src/features/posts/like/queries.ts
@@ -10,9 +10,7 @@ export const useTogglePostLike = (postId: number) => {
   return useMutation({
     mutationFn: async (isCurrentlyLiked: boolean) => {
       const { data } = isCurrentlyLiked
-        ? await api.delete<PostLikeResponse>(
-            `/api/v1/posts/${postId}/like/cancel`
-          )
+        ? await api.delete<PostLikeResponse>(`/api/v1/posts/${postId}/like`)
         : await api.post<PostLikeResponse>(`/api/v1/posts/${postId}/like`)
       return data
     },


### PR DESCRIPTION
## 관련 이슈

- 좋아요 취소 API 엔드포인트 변경

## 작업 내용

- 좋아요 취소 엔드포인트를 `DELETE /api/v1/posts/{post_id}/like/cancel`에서 `DELETE /api/v1/posts/{post_id}/like`로 변경

## 변경 사항

- `src/features/posts/like/queries.ts`: 좋아요 취소 시 호출 URL 수정
- `src/features/posts/like/handler.ts`: MSW 핸들러 URL 수정 (`/like/cancel` → `/like`)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다