### PR TITLE
fix: 좋아요 토글 시 onSettled invalidate로 인한 is_liked 상태 초기화 버그 수정

### DIFF
--- a/src/components/layout/Header/icons.tsx
+++ b/src/components/layout/Header/icons.tsx
@@ -1,15 +1,15 @@
-export function ProfileIcon() {
+export function ProfileIcon({ size = 40 }) {
   return (
     <svg
-      width="40"
-      height="40"
+      width={`${size}`}
+      height={`${size}`}
       viewBox="0 0 40 40"
       fill="none"
       aria-hidden="true"
     >
-      <circle cx="20" cy="20" r="20" fill="#E5E7EB" />
-      <circle cx="20" cy="16" r="6" fill="#9CA3AF" />
-      <path d="M8 34c0-6.627 5.373-12 12-12s12 5.373 12 12" fill="#9CA3AF" />
+      <circle cx="20" cy="20" r="20" fill="#ede6ff" />
+      <circle cx="20" cy="16" r="6" fill="#986be9" />
+      <path d="M8 34c0-6.627 5.373-12 12-12s12 5.373 12 12" fill="#986be9" />
     </svg>
   )
 }

--- a/src/features/posts/like/queries.ts
+++ b/src/features/posts/like/queries.ts
@@ -34,8 +34,5 @@ export const useTogglePostLike = (postId: number) => {
         queryClient.setQueryData(queryKey, context.previous)
       }
     },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey })
-    },
   })
 }


### PR DESCRIPTION
## 관련 이슈

- closes #128

## 작업 내용

- 좋아요 버튼 두 번째 클릭 시 409 Conflict 에러 및 실패 토스트 발생 버그 수정

## 변경 사항

- `useTogglePostLike`의 `onSettled`에서 `invalidateQueries` 제거
  - 좋아요 후 서버 재조회 시 `is_liked: false`가 반환되어 상태가 리셋되던 문제
  - 이제 `onMutate`의 낙관적 업데이트 값을 그대로 유지하고, 실패 시 `onError`에서 롤백

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다