### PR TITLE
fix: 좋아요 및 댓글 관련 버그 수정

### DIFF
--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -46,7 +46,7 @@ export function CommunityComments({ postId }: Props) {
     isLoading,
     isError,
     error,
-  } = useCommentsInfiniteQuery(postId, sortOrder, Boolean(postId))
+  } = useCommentsInfiniteQuery(postId, Boolean(postId))
 
   const queryClient = useQueryClient()
   const { mutate: submitComment, isPending: isSubmitting } =
@@ -169,7 +169,13 @@ export function CommunityComments({ postId }: Props) {
     return () => observer.disconnect()
   }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
-  const allComments = data?.pages.flatMap((page) => page.results) ?? []
+  const allComments = (data?.pages.flatMap((page) => page.results) ?? []).sort(
+    (a, b) => {
+      const diff =
+        new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+      return sortOrder === 'oldest' ? diff : -diff
+    }
+  )
   const totalCount = data?.pages[0]?.count ?? 0
 
   if (isLoading) {

--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -30,7 +30,7 @@ export function CommunityComments({ postId }: Props) {
   const [inputValue, setInputValue] = useState('')
   const [submitError, setSubmitError] = useState(false)
   const [submitErrorMessage, setSubmitErrorMessage] = useState('')
-  const [sortOrder, setSortOrder] = useState<SortOrder>('latest')
+  const [sortOrder, setSortOrder] = useState<SortOrder>('oldest')
   const [deleteToast, setDeleteToast] = useState<{
     visible: boolean
     message: string
@@ -46,7 +46,7 @@ export function CommunityComments({ postId }: Props) {
     isLoading,
     isError,
     error,
-  } = useCommentsInfiniteQuery(postId, Boolean(postId))
+  } = useCommentsInfiniteQuery(postId, sortOrder, Boolean(postId))
 
   const queryClient = useQueryClient()
   const { mutate: submitComment, isPending: isSubmitting } =

--- a/src/components/layout/Header/icons.tsx
+++ b/src/components/layout/Header/icons.tsx
@@ -1,15 +1,15 @@
-export function ProfileIcon() {
+export function ProfileIcon({ size = 40 }) {
   return (
     <svg
-      width="40"
-      height="40"
+      width={`${size}`}
+      height={`${size}`}
       viewBox="0 0 40 40"
       fill="none"
       aria-hidden="true"
     >
-      <circle cx="20" cy="20" r="20" fill="#E5E7EB" />
-      <circle cx="20" cy="16" r="6" fill="#9CA3AF" />
-      <path d="M8 34c0-6.627 5.373-12 12-12s12 5.373 12 12" fill="#9CA3AF" />
+      <circle cx="20" cy="20" r="20" fill="#ede6ff" />
+      <circle cx="20" cy="16" r="6" fill="#986be9" />
+      <path d="M8 34c0-6.627 5.373-12 12-12s12 5.373 12 12" fill="#986be9" />
     </svg>
   )
 }

--- a/src/features/posts/comments/queries.ts
+++ b/src/features/posts/comments/queries.ts
@@ -8,13 +8,9 @@ import type { Comment, CommentsResponse, CommentSubmitRequest } from './types'
 
 const PAGE_SIZE = 10
 
-export function useCommentsInfiniteQuery(
-  postId: number,
-  ordering: 'latest' | 'oldest' = 'oldest',
-  enabled = true
-) {
+export function useCommentsInfiniteQuery(postId: number, enabled = true) {
   return useInfiniteQuery({
-    queryKey: ['posts', postId, 'comments', ordering],
+    queryKey: ['posts', postId, 'comments'],
     queryFn: async ({ pageParam }) => {
       const response = await api.get<CommentsResponse>(
         `/api/v1/posts/${postId}/comments`,
@@ -22,7 +18,6 @@ export function useCommentsInfiniteQuery(
           params: {
             page: pageParam,
             page_size: PAGE_SIZE,
-            ordering: ordering === 'latest' ? '-created_at' : 'created_at',
           },
         }
       )

--- a/src/features/posts/comments/queries.ts
+++ b/src/features/posts/comments/queries.ts
@@ -8,9 +8,13 @@ import type { Comment, CommentsResponse, CommentSubmitRequest } from './types'
 
 const PAGE_SIZE = 10
 
-export function useCommentsInfiniteQuery(postId: number, enabled = true) {
+export function useCommentsInfiniteQuery(
+  postId: number,
+  ordering: 'latest' | 'oldest' = 'oldest',
+  enabled = true
+) {
   return useInfiniteQuery({
-    queryKey: ['posts', postId, 'comments'],
+    queryKey: ['posts', postId, 'comments', ordering],
     queryFn: async ({ pageParam }) => {
       const response = await api.get<CommentsResponse>(
         `/api/v1/posts/${postId}/comments`,
@@ -18,6 +22,7 @@ export function useCommentsInfiniteQuery(postId: number, enabled = true) {
           params: {
             page: pageParam,
             page_size: PAGE_SIZE,
+            ordering: ordering === 'latest' ? '-created_at' : 'created_at',
           },
         }
       )

--- a/src/features/posts/like/handler.ts
+++ b/src/features/posts/like/handler.ts
@@ -17,7 +17,7 @@ export const postLikeHandlers = [
     }
     return HttpResponse.json(body)
   }),
-  http.delete(apiUrl('/api/v1/posts/:post_id/like/cancel'), ({ params }) => {
+  http.delete(apiUrl('/api/v1/posts/:post_id/like'), ({ params }) => {
     const postId = Number(params.post_id)
     const newCount = Math.max(0, likeMockStore.getLikeCount(postId) - 1)
     likeMockStore.likeCountMap.set(postId, newCount)

--- a/src/features/posts/like/queries.ts
+++ b/src/features/posts/like/queries.ts
@@ -10,9 +10,7 @@ export const useTogglePostLike = (postId: number) => {
   return useMutation({
     mutationFn: async (isCurrentlyLiked: boolean) => {
       const { data } = isCurrentlyLiked
-        ? await api.delete<PostLikeResponse>(
-            `/api/v1/posts/${postId}/like/cancel`
-          )
+        ? await api.delete<PostLikeResponse>(`/api/v1/posts/${postId}/like`)
         : await api.post<PostLikeResponse>(`/api/v1/posts/${postId}/like`)
       return data
     },

--- a/src/features/posts/like/queries.ts
+++ b/src/features/posts/like/queries.ts
@@ -34,8 +34,5 @@ export const useTogglePostLike = (postId: number) => {
         queryClient.setQueryData(queryKey, context.previous)
       }
     },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey })
-    },
   })
 }


### PR DESCRIPTION
## Summary
- 좋아요 토글 시 onSettled invalidate로 인한 is_liked 상태 초기화 버그 수정
- 좋아요 취소 엔드포인트를 DELETE /like/cancel → DELETE /like 로 변경
- 댓글 정렬을 서버 대신 클라이언트 사이드에서 처리하도록 변경
- 댓글 정렬 기능 복구 및 기본값 오래된 순으로 변경
- 프로필 이미지 색상 변경

Closes #131

## Test plan
- [ ] 좋아요 토글 후 is_liked 상태가 올바르게 유지되는지 확인
- [ ] 좋아요 취소가 정상 동작하는지 확인
- [ ] 댓글 정렬이 올바르게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)