### PR TITLE
fix: 커뮤니티 링크 외부 URL 이동 및 https 적용 (#137)

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router'
 import logoImg from '@/assets/logo.png'
 import { ROUTES } from '@/constants/routes'
 import { ProfileIcon } from './icons'
@@ -17,7 +16,6 @@ export function Header({
   onLogout,
 }: HeaderProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false)
-  const navigate = useNavigate()
   const { isAuthenticated, user, logout } = useAuthStore()
   const { mutate: requestLogout } = useLogout()
 
@@ -42,12 +40,12 @@ export function Header({
             </a>
 
             <nav className="flex items-center gap-15">
-              <button
-                onClick={() => navigate(ROUTES.COMMUNITY.LIST)}
+              <a
+                href={ROUTES.COMMUNITY.LIST}
                 className="hover:text-primary px-2.5 py-2.5 text-lg tracking-tight text-gray-900 transition-colors duration-150"
               >
                 커뮤니티
-              </button>
+              </a>
               <a
                 href={ROUTES.QNA.LIST}
                 className="hover:text-primary px-2.5 py-2.5 text-lg tracking-tight text-gray-900 transition-colors duration-150"

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -34,9 +34,9 @@ export const ROUTES = {
   },
 
   COMMUNITY: {
-    LIST: '/community',
-    WRITE: '/community/write',
-    DETAIL: '/community/:postId',
-    EDIT: '/community/:postId/edit',
+    LIST: 'https://community.ozcodingschool.site/community',
+    WRITE: 'https://community.ozcodingschool.site/community/write',
+    DETAIL: 'https://community.ozcodingschool.site/community/:postId',
+    EDIT: 'https://community.ozcodingschool.site/community/:postId/edit',
   },
 } as const


### PR DESCRIPTION
## 관련 이슈
- closes #137

## 작업 내용
- 헤더 커뮤니티 버튼을 navigate()에서 <a href> 태그로 교체
- routes.ts Community URL을 절대 경로에서 https 외부 URL로 변경

## 변경 사항
- src/components/layout/Header/Header.tsx: button → a 태그, useNavigate 제거
- src/constants/routes.ts: Community URL https 절대 URL로 수정

## 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다