### PR TITLE
fix: community 페이지 내부 navigate 절대 URL → 상대 경로로 수정 (#143)

### DIFF
--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -57,7 +57,7 @@ export function CommunityComments({ postId }: Props) {
     isError && axios.isAxiosError(error) && error.response?.status === 404
 
   const handleToastClose = useCallback(() => {
-    navigate(ROUTES.COMMUNITY.LIST, { replace: true })
+    navigate('/community', { replace: true })
   }, [navigate])
 
   const handleSubmit = useCallback(() => {
@@ -84,7 +84,7 @@ export function CommunityComments({ postId }: Props) {
           } else if (status === 404) {
             setSubmitErrorMessage('존재하지 않는 게시물입니다.')
             setSubmitError(true)
-            navigate(ROUTES.COMMUNITY.LIST, { replace: true })
+            navigate('/community', { replace: true })
           } else {
             setSubmitErrorMessage(
               '댓글 등록에 실패했습니다. 잠시 후 다시 시도해주세요.'
@@ -205,7 +205,7 @@ export function CommunityComments({ postId }: Props) {
           const action = deleteToast.closeAction
           setDeleteToast((prev) => ({ ...prev, visible: false }))
           if (action === 'navigate-list') {
-            navigate(ROUTES.COMMUNITY.LIST, { replace: true })
+            navigate('/community', { replace: true })
           } else if (action === 'navigate-login') {
             window.location.href = ROUTES.AUTH.LOGIN
           } else if (action === 'refresh') {

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -56,7 +56,7 @@ export function CommunityEditPage() {
 
   useEffect(() => {
     if (isPostError) {
-      navigate(ROUTES.COMMUNITY.LIST, { replace: true })
+      navigate('/community', { replace: true })
     }
   }, [isPostError, navigate])
 
@@ -69,7 +69,7 @@ export function CommunityEditPage() {
           variant: 'success',
         })
         setTimeout(() => {
-          navigate(ROUTES.COMMUNITY.DETAIL.replace(':postId', postId!))
+          navigate(`/community/${postId}`)
         }, 800)
       },
       onError: (error) => {

--- a/src/pages/community/CommunityListPage.tsx
+++ b/src/pages/community/CommunityListPage.tsx
@@ -158,7 +158,7 @@ export function CommunityListPage() {
       window.location.href = ROUTES.AUTH.LOGIN
       return
     }
-    navigate(ROUTES.COMMUNITY.WRITE)
+    navigate('/community/write')
   }
 
   const currentIndex = categoryTabs.findIndex((t) => t.value === category)
@@ -300,11 +300,7 @@ export function CommunityListPage() {
             categoryName={
               categoriesData?.find((c) => c.id === post.category)?.name
             }
-            onClick={() =>
-              navigate(
-                ROUTES.COMMUNITY.DETAIL.replace(':postId', String(post.id))
-              )
-            }
+            onClick={() => navigate(`/community/${post.id}`)}
           />
         ))}
       </div>

--- a/src/pages/community/CommunityWritePage.tsx
+++ b/src/pages/community/CommunityWritePage.tsx
@@ -58,7 +58,7 @@ export function CommunityWritePage() {
           variant: 'success',
         })
         navTimerRef.current = setTimeout(() => {
-          navigate(ROUTES.COMMUNITY.DETAIL.replace(':postId', String(data.pk)))
+          navigate(`/community/${data.pk}`)
         }, 800)
       },
       onError: (error) => {
@@ -90,7 +90,7 @@ export function CommunityWritePage() {
         isCategoriesError={isCategoriesError}
         isCategoriesLoading={isCategoriesLoading}
         onSubmit={handleSubmit}
-        onCancel={() => navigate(ROUTES.COMMUNITY.LIST)}
+        onCancel={() => navigate('/community')}
         isPending={isPending}
       />
       <Toast


### PR DESCRIPTION
## 관련 이슈
- closes #143

## 작업 내용
- community 페이지/컴포넌트 내부의 `navigate(ROUTES.COMMUNITY.*)` 호출을 모두 직접 상대 경로로 교체

## 변경 사항
- src/pages/community/CommunityListPage.tsx: 글쓰기 이동, 게시글 클릭 이동
- src/pages/community/CommunityWritePage.tsx: 작성 성공 후 이동, 취소 버튼
- src/pages/community/CommunityEditPage.tsx: 에러 시 이동, 수정 성공 후 이동
- src/components/community/CommunityComments/CommunityComments.tsx: 목록으로 이동 3곳

## 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다