### PR TITLE
feat: 댓글 목록 조회 및 무한 스크롤 기능 구현 (#146)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -31,7 +31,8 @@
       "Bash(Select-Object -ExpandProperty FullName)",
       "Bash(Remove-Item -Recurse -Force \"c:\\\\Users\\\\이용기\\\\Desktop\\\\2팀\\\\oz_externship_fe_08_team2\\\\src\\\\features\\\\accounts\" -ErrorAction SilentlyContinue)",
       "Bash(Write-Host \"done\")",
-      "Bash(xargs grep:*)"
+      "Bash(xargs grep:*)",
+      "Bash(curl -s https://api.ozcodingschool.site/api/schema/)"
     ]
   },
   "enabledMcpjsonServers": [
@@ -54,4 +55,4 @@
       }
     ]
   }
-  }
+}

--- a/src/components/community/CommentInput/CommentInput.tsx
+++ b/src/components/community/CommentInput/CommentInput.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, type ReactNode } from 'react'
 import { Toast } from '@/components'
-import { useUserSearch } from '@/features/accounts/user-search'
 import { UserTagList } from '@/components/community/UserTagList'
+import type { UserSearchResult } from '@/features/accounts/user-search'
 
 interface CommentInputProps {
   value: string
@@ -11,6 +11,7 @@ interface CommentInputProps {
   submitError: boolean
   submitErrorMessage?: string
   onSubmitErrorClose: () => void
+  knownUsers?: UserSearchResult[]
 }
 
 function getMentionQuery(text: string, cursorPos: number): string | null {
@@ -72,14 +73,13 @@ export function CommentInput({
   submitError,
   submitErrorMessage = '댓글 등록에 실패했습니다. 잠시 후 다시 시도해주세요.',
   onSubmitErrorClose,
+  knownUsers = [],
 }: CommentInputProps) {
   const [isFocused, setIsFocused] = useState(false)
   const [mentionQuery, setMentionQuery] = useState<string | null>(null)
   const [taggedNicknames, setTaggedNicknames] = useState<Set<string>>(new Set())
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const mirrorRef = useRef<HTMLDivElement>(null)
-
-  const { data: searchData } = useUserSearch(mentionQuery ?? '')
 
   const syncScroll = useCallback(() => {
     if (mirrorRef.current && textareaRef.current) {
@@ -141,7 +141,12 @@ export function CommentInput({
     [value, onChange]
   )
 
-  const users = searchData?.results ?? []
+  const users =
+    mentionQuery !== null
+      ? knownUsers.filter((u) =>
+          u.nickname.toLowerCase().includes(mentionQuery.toLowerCase())
+        )
+      : []
   const showDropdown = mentionQuery !== null && users.length > 0
 
   return (

--- a/src/components/community/CommentInput/CommentInput.tsx
+++ b/src/components/community/CommentInput/CommentInput.tsx
@@ -112,10 +112,11 @@ export function CommentInput({
         setMentionQuery(null)
         return
       }
-      const cursor = textareaRef.current?.selectionStart ?? value.length
-      setMentionQuery(getMentionQuery(value, cursor))
+      const target = e.currentTarget
+      const cursor = target.selectionStart ?? target.value.length
+      setMentionQuery(getMentionQuery(target.value, cursor))
     },
-    [value]
+    []
   )
 
   const handleSelectUser = useCallback(

--- a/src/components/community/CommentLoadingDots/CommentLoadingDots.tsx
+++ b/src/components/community/CommentLoadingDots/CommentLoadingDots.tsx
@@ -3,21 +3,21 @@ export function CommentLoadingDots() {
     <>
       <style>{`
         @keyframes comment-wave {
-          0%, 60%, 100% { transform: translateY(0); }
-          30% { transform: translateY(-12px); }
+          0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+          30% { transform: translateY(-10px); opacity: 1; }
         }
         .comment-dot {
-          animation: comment-wave 1.2s ease-in-out infinite;
+          animation: comment-wave 1s ease-in-out infinite;
         }
       `}</style>
-      <div className="flex items-center justify-center gap-3 py-4">
-        {[0, 1, 2].map((i) => (
+      <div className="flex items-center justify-center gap-2 py-4">
+        {[0, 1, 2, 3, 4].map((i) => (
           <span
             key={i}
-            className="comment-dot inline-block h-3 w-3 rounded-full"
+            className="comment-dot inline-block h-2.5 w-2.5 rounded-full"
             style={{
               backgroundColor: '#6201E0',
-              animationDelay: `${i * 0.2}s`,
+              animationDelay: `${i * 0.15}s`,
             }}
           />
         ))}

--- a/src/components/community/CommentLoadingDots/CommentLoadingDots.tsx
+++ b/src/components/community/CommentLoadingDots/CommentLoadingDots.tsx
@@ -11,13 +11,13 @@ export function CommentLoadingDots() {
         }
       `}</style>
       <div className="flex items-center justify-center gap-2 py-4">
-        {[0, 1, 2, 3, 4].map((i) => (
+        {[0, 1, 2].map((i) => (
           <span
             key={i}
             className="comment-dot inline-block h-2.5 w-2.5 rounded-full"
             style={{
               backgroundColor: '#6201E0',
-              animationDelay: `${i * 0.15}s`,
+              animationDelay: `${i * 0.2}s`,
             }}
           />
         ))}

--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -27,7 +27,6 @@ export function CommunityComments({ postId }: Props) {
   const isInitialized = useAuthStore((state) => state.isInitialized)
   const user = useAuthStore((state) => state.user)
   const loadMoreRef = useRef<HTMLDivElement>(null)
-  const isAtBottomRef = useRef(false)
   const [inputValue, setInputValue] = useState('')
   const [submitError, setSubmitError] = useState(false)
   const [submitErrorMessage, setSubmitErrorMessage] = useState('')
@@ -152,7 +151,8 @@ export function CommunityComments({ postId }: Props) {
     [deleteComment]
   )
 
-  // 무한스크롤: sentinel 가시성 추적 (첫 관찰은 항상 스킵 — 페이지 로드·복귀 시 즉시 발동 방지)
+  // 무한스크롤: sentinel이 viewport에 들어올 때 다음 페이지 요청
+  // 첫 관찰(isFirstFire)은 스킵 — 페이지 로드/복귀 시 즉시 발동 방지
   useEffect(() => {
     const el = loadMoreRef.current
     if (!el) return
@@ -160,7 +160,6 @@ export function CommunityComments({ postId }: Props) {
     let isFirstFire = true
     const observer = new IntersectionObserver(
       (entries) => {
-        isAtBottomRef.current = entries[0].isIntersecting
         if (isFirstFire) {
           isFirstFire = false
           return
@@ -175,13 +174,6 @@ export function CommunityComments({ postId }: Props) {
     observer.observe(el)
     return () => observer.disconnect()
   }, [hasNextPage, isFetchingNextPage, fetchNextPage])
-
-  // 페이지 fetch 완료 후 sentinel이 여전히 보이면 다음 페이지 요청 (연속 스크롤)
-  useEffect(() => {
-    if (!isFetchingNextPage && isAtBottomRef.current && hasNextPage) {
-      fetchNextPage()
-    }
-  }, [isFetchingNextPage, hasNextPage, fetchNextPage])
 
   const allComments = (data?.pages.flatMap((page) => page.results) ?? []).sort(
     (a, b) => {

--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -151,20 +151,29 @@ export function CommunityComments({ postId }: Props) {
     [deleteComment]
   )
 
+  // 스크롤 여부 추적 — 한 번이라도 스크롤해야 무한스크롤 허용 (자동 발동 방지)
+  const hasScrolledRef = useRef(false)
+  useEffect(() => {
+    const onScroll = () => {
+      hasScrolledRef.current = true
+    }
+    window.addEventListener('scroll', onScroll, { passive: true, once: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
   // 무한스크롤: sentinel이 viewport에 들어올 때 다음 페이지 요청
-  // 첫 관찰(isFirstFire)은 스킵 — 페이지 로드/복귀 시 즉시 발동 방지
   useEffect(() => {
     const el = loadMoreRef.current
     if (!el) return
 
-    let isFirstFire = true
     const observer = new IntersectionObserver(
       (entries) => {
-        if (isFirstFire) {
-          isFirstFire = false
-          return
-        }
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+        if (
+          entries[0].isIntersecting &&
+          hasNextPage &&
+          !isFetchingNextPage &&
+          hasScrolledRef.current
+        ) {
           fetchNextPage()
         }
       },

--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -151,6 +151,27 @@ export function CommunityComments({ postId }: Props) {
     [deleteComment]
   )
 
+  // 최소 1초 로딩 표시 — 초기 로딩
+  const [showInitialLoader, setShowInitialLoader] = useState(true)
+  useEffect(() => {
+    if (!isLoading) {
+      const timer = setTimeout(() => setShowInitialLoader(false), 1000)
+      return () => clearTimeout(timer)
+    }
+  }, [isLoading])
+
+  // 최소 1초 로딩 표시 — 무한스크롤 로딩
+  const [showScrollLoader, setShowScrollLoader] = useState(false)
+  useEffect(() => {
+    if (isFetchingNextPage) {
+      const timer = setTimeout(() => setShowScrollLoader(true), 0)
+      return () => clearTimeout(timer)
+    } else {
+      const timer = setTimeout(() => setShowScrollLoader(false), 1000)
+      return () => clearTimeout(timer)
+    }
+  }, [isFetchingNextPage])
+
   // 스크롤 여부 추적 — 한 번이라도 스크롤해야 무한스크롤 허용 (자동 발동 방지)
   const hasScrolledRef = useRef(false)
   useEffect(() => {
@@ -193,7 +214,7 @@ export function CommunityComments({ postId }: Props) {
   )
   const totalCount = data?.pages[0]?.count ?? 0
 
-  if (isLoading) {
+  if (isLoading || showInitialLoader) {
     return (
       <section className="mt-8">
         <CommentLoadingDots />
@@ -273,7 +294,7 @@ export function CommunityComments({ postId }: Props) {
 
       {/* 무한스크롤 감지 영역 + 로딩 표시 */}
       <div ref={loadMoreRef} className="py-2">
-        {isFetchingNextPage && <CommentLoadingDots />}
+        {showScrollLoader && <CommentLoadingDots />}
       </div>
     </section>
   )

--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -27,6 +27,7 @@ export function CommunityComments({ postId }: Props) {
   const isInitialized = useAuthStore((state) => state.isInitialized)
   const user = useAuthStore((state) => state.user)
   const loadMoreRef = useRef<HTMLDivElement>(null)
+  const isAtBottomRef = useRef(false)
   const [inputValue, setInputValue] = useState('')
   const [submitError, setSubmitError] = useState(false)
   const [submitErrorMessage, setSubmitErrorMessage] = useState('')
@@ -151,25 +152,20 @@ export function CommunityComments({ postId }: Props) {
     [deleteComment]
   )
 
-  // 무한스크롤 IntersectionObserver
+  // 무한스크롤: sentinel 가시성 추적 (첫 관찰은 항상 스킵 — 페이지 로드·복귀 시 즉시 발동 방지)
   useEffect(() => {
     const el = loadMoreRef.current
     if (!el) return
 
-    let isInitial = true
+    let isFirstFire = true
     const observer = new IntersectionObserver(
       (entries) => {
-        if (!entries[0].isIntersecting) {
-          isInitial = false
+        isAtBottomRef.current = entries[0].isIntersecting
+        if (isFirstFire) {
+          isFirstFire = false
           return
         }
-        // 첫 관찰(페이지 로드 직후)은 사용자가 실제로 스크롤한 경우에만 허용
-        if (isInitial && window.scrollY === 0) {
-          isInitial = false
-          return
-        }
-        isInitial = false
-        if (hasNextPage && !isFetchingNextPage) {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
           fetchNextPage()
         }
       },
@@ -179,6 +175,13 @@ export function CommunityComments({ postId }: Props) {
     observer.observe(el)
     return () => observer.disconnect()
   }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  // 페이지 fetch 완료 후 sentinel이 여전히 보이면 다음 페이지 요청 (연속 스크롤)
+  useEffect(() => {
+    if (!isFetchingNextPage && isAtBottomRef.current && hasNextPage) {
+      fetchNextPage()
+    }
+  }, [isFetchingNextPage, hasNextPage, fetchNextPage])
 
   const allComments = (data?.pages.flatMap((page) => page.results) ?? []).sort(
     (a, b) => {

--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -156,13 +156,24 @@ export function CommunityComments({ postId }: Props) {
     const el = loadMoreRef.current
     if (!el) return
 
+    let isInitial = true
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+        if (!entries[0].isIntersecting) {
+          isInitial = false
+          return
+        }
+        // 첫 관찰(페이지 로드 직후)은 사용자가 실제로 스크롤한 경우에만 허용
+        if (isInitial && window.scrollY === 0) {
+          isInitial = false
+          return
+        }
+        isInitial = false
+        if (hasNextPage && !isFetchingNextPage) {
           fetchNextPage()
         }
       },
-      { threshold: 0.5 }
+      { threshold: 0.1 }
     )
 
     observer.observe(el)

--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useState } from 'react'
+import { useEffect, useRef, useCallback, useState, useMemo } from 'react'
 import { useNavigate } from 'react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
@@ -30,7 +30,7 @@ export function CommunityComments({ postId }: Props) {
   const [inputValue, setInputValue] = useState('')
   const [submitError, setSubmitError] = useState(false)
   const [submitErrorMessage, setSubmitErrorMessage] = useState('')
-  const [sortOrder, setSortOrder] = useState<SortOrder>('oldest')
+  const [sortOrder, setSortOrder] = useState<SortOrder>('newest')
   const [deleteToast, setDeleteToast] = useState<{
     visible: boolean
     message: string
@@ -214,6 +214,14 @@ export function CommunityComments({ postId }: Props) {
   )
   const totalCount = data?.pages[0]?.count ?? 0
 
+  // 로드된 댓글 작성자들 (중복 제거) — @멘션 후보로 사용
+  const knownUsers = useMemo(() => {
+    const seen = new Set<number>()
+    return (data?.pages.flatMap((page) => page.results) ?? [])
+      .map((c) => c.author)
+      .filter((a) => !seen.has(a.id) && seen.add(a.id))
+  }, [data])
+
   if (isLoading || showInitialLoader) {
     return (
       <section className="mt-8">
@@ -262,6 +270,7 @@ export function CommunityComments({ postId }: Props) {
           submitError={submitError}
           submitErrorMessage={submitErrorMessage}
           onSubmitErrorClose={() => setSubmitError(false)}
+          knownUsers={knownUsers}
         />
       )}
 

--- a/src/components/community/CommunityComments/CommunityComments.tsx
+++ b/src/components/community/CommunityComments/CommunityComments.tsx
@@ -30,7 +30,7 @@ export function CommunityComments({ postId }: Props) {
   const [inputValue, setInputValue] = useState('')
   const [submitError, setSubmitError] = useState(false)
   const [submitErrorMessage, setSubmitErrorMessage] = useState('')
-  const [sortOrder, setSortOrder] = useState<SortOrder>('newest')
+  const [sortOrder, setSortOrder] = useState<SortOrder>('latest')
   const [deleteToast, setDeleteToast] = useState<{
     visible: boolean
     message: string

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,12 +5,12 @@ import { QueryProvider } from './providers/QueryProvider'
 import './App.css'
 import App from './App'
 
-// async function enableMocking() {
-//   if (import.meta.env.DEV) {
-//     const { worker } = await import('./mocks/browser')
-//     return worker.start({ onUnhandledRequest: 'bypass' })
-//   }
-// }
+async function enableMocking() {
+  if (import.meta.env.DEV) {
+    const { worker } = await import('./mocks/browser')
+    return worker.start({ onUnhandledRequest: 'bypass' })
+  }
+}
 
 function renderApp() {
   createRoot(document.getElementById('root')!).render(
@@ -24,11 +24,9 @@ function renderApp() {
   )
 }
 
-// enableMocking()
-//   .then(() => renderApp())
-//   .catch((error) => {
-//     console.error('MSW 초기화 실패:', error)
-//     renderApp()
-//   })
-
-renderApp()
+enableMocking()
+  .then(() => renderApp())
+  .catch((error) => {
+    console.error('MSW 초기화 실패:', error)
+    renderApp()
+  })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,12 +5,12 @@ import { QueryProvider } from './providers/QueryProvider'
 import './App.css'
 import App from './App'
 
-async function enableMocking() {
-  if (import.meta.env.DEV) {
-    const { worker } = await import('./mocks/browser')
-    return worker.start({ onUnhandledRequest: 'bypass' })
-  }
-}
+// async function enableMocking() {
+//   if (import.meta.env.DEV) {
+//     const { worker } = await import('./mocks/browser')
+//     return worker.start({ onUnhandledRequest: 'bypass' })
+//   }
+// }
 
 function renderApp() {
   createRoot(document.getElementById('root')!).render(
@@ -24,9 +24,11 @@ function renderApp() {
   )
 }
 
-enableMocking()
-  .then(() => renderApp())
-  .catch((error) => {
-    console.error('MSW 초기화 실패:', error)
-    renderApp()
-  })
+// enableMocking()
+//   .then(() => renderApp())
+//   .catch((error) => {
+//     console.error('MSW 초기화 실패:', error)
+//     renderApp()
+//   })
+
+renderApp()

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,12 +5,15 @@ import { QueryProvider } from './providers/QueryProvider'
 import './App.css'
 import App from './App'
 
-// async function enableMocking() {
-//   if (import.meta.env.DEV) {
-//     const { worker } = await import('./mocks/browser')
-//     return worker.start({ onUnhandledRequest: 'bypass' })
-//   }
-// }
+async function enableMocking() {
+  if (import.meta.env.DEV) {
+    const { setupWorker } = await import('msw/browser')
+    const { userSearchHandlers } =
+      await import('./features/accounts/user-search')
+    const worker = setupWorker(...userSearchHandlers)
+    return worker.start({ onUnhandledRequest: 'bypass' })
+  }
+}
 
 function renderApp() {
   createRoot(document.getElementById('root')!).render(
@@ -24,11 +27,9 @@ function renderApp() {
   )
 }
 
-// enableMocking()
-//   .then(() => renderApp())
-//   .catch((error) => {
-//     console.error('MSW 초기화 실패:', error)
-//     renderApp()
-//   })
-
-renderApp()
+enableMocking()
+  .then(() => renderApp())
+  .catch((error) => {
+    console.error('MSW 초기화 실패:', error)
+    renderApp()
+  })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,31 +5,12 @@ import { QueryProvider } from './providers/QueryProvider'
 import './App.css'
 import App from './App'
 
-async function enableMocking() {
-  if (import.meta.env.DEV) {
-    const { setupWorker } = await import('msw/browser')
-    const { userSearchHandlers } =
-      await import('./features/accounts/user-search')
-    const worker = setupWorker(...userSearchHandlers)
-    return worker.start({ onUnhandledRequest: 'bypass' })
-  }
-}
-
-function renderApp() {
-  createRoot(document.getElementById('root')!).render(
-    <StrictMode>
-      <BrowserRouter>
-        <QueryProvider>
-          <App />
-        </QueryProvider>
-      </BrowserRouter>
-    </StrictMode>
-  )
-}
-
-enableMocking()
-  .then(() => renderApp())
-  .catch((error) => {
-    console.error('MSW 초기화 실패:', error)
-    renderApp()
-  })
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <BrowserRouter>
+      <QueryProvider>
+        <App />
+      </QueryProvider>
+    </BrowserRouter>
+  </StrictMode>
+)

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -6,7 +6,7 @@ import { postDetailHandlers } from '@/features/posts/detail'
 import { editHandlers } from '@/features/posts/edit'
 import { postLikeHandlers } from '@/features/posts/like'
 import { postDeleteHandlers } from '@/features/posts/delete'
-// import { commentsHandlers } from '@/features/posts/comments'
+import { commentsHandlers } from '@/features/posts/comments'
 import { userSearchHandlers } from '@/features/accounts/user-search'
 // import { logoutHandlers } from '@/features/accounts/logout'
 import { meHandlers } from '@/features/accounts/me'
@@ -25,7 +25,7 @@ export const handlers = [
   ...writeHandlers,
   ...postDetailHandlers,
   ...editHandlers,
-  // ...commentsHandlers,
+  ...commentsHandlers,
   ...postLikeHandlers,
   ...postDeleteHandlers,
   ...userSearchHandlers,


### PR DESCRIPTION
## 관련 이슈

- closes #146

## 작업 내용

- 댓글 목록 무한 스크롤 구현 (10개씩, IntersectionObserver 기반)
- 댓글 기본 정렬 최신순 변경 및 SortOrder 타입 오타 수정
- 유저 태그(@닉네임) 실제 tagged_users 데이터 연동
- 유저 검색 MSW 선택적 활성화 (실제 API 미지원 엔드포인트 대체)
- 실제 API 전환 (MSW 비활성화)

## 변경 사항

- 무한 스크롤 첫 관찰 스킵으로 페이지 복귀 시 즉시 발동 버그 수정
- 로딩 인디케이터 피그마 디자인 반영 및 최소 1초 표시 보장
- 댓글 입력 시 멘션 쿼리 처리 개선

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다